### PR TITLE
Fix #56: Catch and report missing layers and interfaces

### DIFF
--- a/charmtools/build/__init__.py
+++ b/charmtools/build/__init__.py
@@ -24,6 +24,10 @@ from charmtools import utils
 log = logging.getLogger("build")
 
 
+class BuildError(Exception):
+    pass
+
+
 class Configable(object):
     CONFIG_FILE = None
 
@@ -83,7 +87,7 @@ class Fetched(Configable):
                 self.directory = path(fetcher.fetch(self.target_repo))
 
         if not self.directory.exists():
-            raise OSError(
+            raise BuildError(
                 "Unable to locate {}. "
                 "Do you need to set {}?".format(
                     self.url, self.ENVIRON))
@@ -522,7 +526,11 @@ def main(args=None):
 
     if not build.output_dir:
         build.normalize_outputdir()
-    build()
+    try:
+        build()
+    except BuildError as e:
+        log.error(*e.args)
+        raise SystemExit(1)
 
 
 if __name__ == '__main__':

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -61,7 +61,7 @@ class InterfaceFetcher(fetchers.LocalFetcher):
                     result = None
                 if result and result.ok:
                     result = result.json()
-                    if "repo" in result:
+                    if result.get("repo"):
                         return result
             return {}
 


### PR DESCRIPTION
```
$ charm build
build: Composing into /home/johnsca/juju/envs/dev
build: Unable to locate layer:dummy. Do you need to set LAYER_PATH?
```