### PR TITLE
Fix wheelhouse containing platform specific wheels

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -493,9 +493,9 @@ class WheelhouseTactic(ExactMatch, Tactic):
     def _add(self, pip, wheelhouse, *reqs):
         with utils.tempdir(chdir=False) as temp_dir:
             # put in a temp dir first to ensure we track all of the files
-            utils.Process((pip, 'wheel',
+            utils.Process((pip, 'install',
                            '--no-binary', ':all:',
-                           '-w', temp_dir) +
+                           '-d', temp_dir) +
                           reqs).throw_on_error()()
             for wheel in temp_dir.files():
                 dest = wheelhouse / wheel.basename()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -255,14 +255,14 @@ class TestBuild(unittest.TestCase):
             with mock.patch("path.Path.files"):
                 bu()
                 Process.assert_has_call((
-                    '/tmp/bin/pip', 'wheel',
+                    '/tmp/bin/pip', 'install',
                     '--no-binary', ':all:',
-                    '-w', '/tmp',
+                    '-d', '/tmp',
                     'pip'))
                 Process.assert_called_with((
-                    '/tmp/bin/pip', 'wheel',
+                    '/tmp/bin/pip', 'install',
                     '--no-binary', ':all:',
-                    '-w', '/tmp',
+                    '-d', '/tmp',
                     '-r', self.dirname / 'trusty/whlayer/wheelhouse.txt'))
 
 


### PR DESCRIPTION
Apparently, I completely misunderstood the point of the `--no-binary` option for `pip wheel`.  It actually controls what `pip` pulls down from pypi.python.org and not what gets generated in the wheelhouse.  I've been told that wheels are inherently binary, pre-compiled, and platform specific.

But it seems that using `pip install --download wheelhouse/ --no-binary :all:` instead of `pip wheel -w wheelhouse/ --no-binary :all:` gets us what we want.  Technically, the result is no longer a wheelhouse, since it contains (only) sdists, so I'd be ok with changing the name to "pydeps" and "pydeps.txt" or similar, but for now I left it as "wheelhouse".