### PR TITLE
pip 8.0.0 wreaks havoc. lock it to 7.X

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -621,7 +621,6 @@ class WheelhouseTactic(ExactMatch, Tactic):
         if create_venv:
             utils.Process(('virtualenv', '--python', 'python3', venv)).throw_on_error()()
             utils.Process((pip, 'install', '-U', 'pip', 'wheel')).throw_on_error()()
-            self._add(pip, wheelhouse, 'pip')
         for tactic in self.previous:
             tactic(venv)
         self._add(pip, wheelhouse, '-r', self.entity)


### PR DESCRIPTION
This either needs to be handled here, or pip should simply be defined in the "base" layer and L624 can just be removed