### PR TITLE
Added PowerShell biolerplate generation.

### DIFF
--- a/charmtools/create.py
+++ b/charmtools/create.py
@@ -86,6 +86,9 @@ def main():
             "Using default charm template (%s). To select a different "
             "template, use the -t option.", DEFAULT_TEMPLATE)
         args.template = DEFAULT_TEMPLATE
+    elif args.template not in get_installed_templates():
+        raise Exception("No template available for '%s'. Available templates "
+                        "may be listed by running 'charm create --help'.")
 
     generator = CharmGenerator(args)
     try:

--- a/charmtools/templates/powershell/__init__.py
+++ b/charmtools/templates/powershell/__init__.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+#
+#    Copyright (C) 2016  Canonical Ltd.
+#    Copyright (C) 2016 Cloudbase Solutions SRL
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .template import PowerShellCharmTemplate  # noqa

--- a/charmtools/templates/powershell/template.py
+++ b/charmtools/templates/powershell/template.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+#
+#    Copyright (C) 2016  Canonical Ltd.
+#    Copyright (C) 2016 Cloudbase Solutions SRL
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import os.path as path
+import shutil
+import subprocess
+
+from charmtools.generators import CharmTemplate
+
+
+class PowerShellCharmTemplate(CharmTemplate):
+    """ CharmTemplate specific to PowerShell charms. """
+
+    # _EXTRA_FILES is the list of names of files present in the git repo
+    # we don't want transferred over to the charm template:
+    _EXTRA_FILES = ["README.md", ".git", ".gitmodules"]
+
+    _TEMPLATE_URL = "https://github.com/cloudbase/windows-charms-boilerplate"
+
+    def __init__(self):
+        self.skip_parsing += ["*.ps1", "*.psm1"]
+
+    def create_charm(self, config, output_dir):
+        cmd = "git clone --recursive {} {}".format(
+            self._TEMPLATE_URL, output_dir
+        )
+
+        try:
+            subprocess.check_call(cmd.split())
+        except OSError as e:
+            raise Exception(
+                "The below error has ocurred whilst attempting to clone"
+                "the powershell charm template. Please make sure you have"
+                "git installed on your system.\n" + e
+            )
+
+        # iterate and remove all the unwanted files from the git repo:
+        for item in [path.join(output_dir, i) for i in self._EXTRA_FILES]:
+            if not path.exists(item):
+                continue
+
+            if path.isdir(item) and not path.islink(item):
+                shutil.rmtree(item)
+            else:
+                os.remove(item)

--- a/charmtools/templates/python/files/scripts/charm_helpers_sync.py
+++ b/charmtools/templates/python/files/scripts/charm_helpers_sync.py
@@ -54,7 +54,7 @@ def _is_pyfile(path):
 def ensure_init(path):
     '''
     ensure directories leading up to path are importable, omitting
-    parent directory, eg path='/hooks/helpers/foo'/:
+    parent directory, eg path='/hooks/helpers/foo/':
         hooks/
         hooks/helpers/__init__.py
         hooks/helpers/foo/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,9 @@ setup(
             'python = charmtools.templates.python_services'
             ':PythonServicesCharmTemplate',
             'ansible = charmtools.templates.ansible:AnsibleCharmTemplate',
-            'chef = charmtools.templates.chef:ChefCharmTemplate'
+            'chef = charmtools.templates.chef:ChefCharmTemplate',
+            'powershell = '
+                'charmtools.templates.powershell:PowerShellCharmTemplate',
         ]
     },
 )


### PR DESCRIPTION
This PR brings support for generation of a powershell template with `charm create`.

We chose to just do an exec call to git for a couple of reasons:
*  the boilerplate code itself depends on our [Juju Modules](https://github.com/cloudbase/juju-powershell-modules/tree/master).
* the Juju modules must remain a stand-alone project, as they are generally useful.
* the template's code and the Juju modules must stay synced.
* as the old Romanian saying "may the neighbour's goat die too" goes; the Python template's setup does an exec call to bzr too, so requiring git doesn't seem that unreasonable...