### PR TITLE
Addresses issue 99 where Juju has a problem with strings starting with zero

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -319,7 +319,8 @@ class YAMLTactic(SerializedTactic):
     def dump(self, data):
         yaml.dump(data, self.target_file.open('w'),
                   Dumper=yaml.RoundTripDumper,
-                  default_flow_style=False)
+                  default_flow_style=False,
+                  default_style='"')
 
 
 class JSONTactic(SerializedTactic):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -49,6 +49,12 @@ class TestBuild(unittest.TestCase):
         config_data = yaml.load(config.open())['options']
         self.assertIn("bind-address", config_data)
         self.assertNotIn("vip", config_data)
+        self.assertIn("key", config_data)
+        self.assertEqual(config_data["key"]["default"], None)
+        # Issue #99 where strings lose their quotes in a charm build.
+        self.assertIn("numeric-string", config_data)
+        default_value = config_data['numeric-string']['default']
+        self.assertEqual(default_value, "0123456789", "value must be a string")
 
         cyaml = base / "layer.yaml"
         self.assertTrue(cyaml.exists())
@@ -79,8 +85,7 @@ class TestBuild(unittest.TestCase):
         self.assertEquals(data["signatures"]['metadata.yaml'], [
             u'foo',
             "dynamic",
-            u'01021a65fc131827805edfcbd4f81a897d'
-            u'01a0415f2a20a1179035dc85473a5f'
+            u'bc361aa3407cb8b514d3352984af306b4330d27a2e8f2c7891153ea99f6b11ac'
             ])
 
         storage_attached = base / "hooks/data-storage-attached"

--- a/tests/trusty/mysql/config.yaml
+++ b/tests/trusty/mysql/config.yaml
@@ -1,4 +1,8 @@
 options:
+    numeric-string:
+        default: "0123456789"
+        description: "Charm-tools issue #99 indicated there was a bug with rendering strings that start with zero losing their string quotes."
+        type: string
     dataset-size:
         default: '80%'
         description: How much data do you want to keep in memory in the DB. This will be used to tune settings in the database server appropriately. Any more specific settings will override these defaults though. This currently sets innodb_buffer_pool_size or key_cache_size depending on the setting in preferred-storage-engine. If query-cache-type is set to 'ON' or 'DEMAND' 20% of this is given to query-cache-size. Suffix this value with 'K','M','G', or 'T' to get the relevant kilo/mega/etc. bytes. If suffixed with %, one will get that percentage of RAM devoted to dataset and (if enabled) query cache.
@@ -137,5 +141,5 @@ options:
           Cron schedule used for backups. If empty backups are disabled
     backup_retention_count:
         default: 7
-        type: int 
+        type: int
         description: Number of recent backups to retain.


### PR DESCRIPTION
This pull forces all strings to use quotes so Juju does not try to read the yaml string 01182252 as an int.

Adding configuration and tests so this does not revert in the future.

I also had to fix a hash on metadata.yaml in the tests, don't know what that was about other than the test was failing when I found it.

