### PR TITLE
During `charm build`, suggest a 'repo' key for layer.yaml (if missing)

### DIFF
--- a/charmtools/fetchers.py
+++ b/charmtools/fetchers.py
@@ -122,7 +122,7 @@ class Fetcher(object):
 
 class BzrFetcher(Fetcher):
     MATCH = re.compile(r"""
-    ^(lp:|launchpad:|https?://((code|www)\.)?launchpad.net/)
+    ^(lp:|launchpad:|https?://((code|www)\.)?launchpad.net/|bzr\+ssh://[^/]+/)
     (?P<repo>[^@]*)(@(?P<revision>.*))?$
     """, re.VERBOSE)
 
@@ -177,7 +177,7 @@ class LaunchpadGitFetcher(Fetcher):
 
 class GithubFetcher(Fetcher):
     MATCH = re.compile(r"""
-    ^(gh:|github:|https?://(www\.)?github.com/)
+    ^(gh:|github:|https?://(www\.)?github.com/|git@github.com:)
     (?P<repo>[^@]*)(@(?P<revision>.*))?$
     """, re.VERBOSE)
 

--- a/charmtools/repofinder.py
+++ b/charmtools/repofinder.py
@@ -1,0 +1,86 @@
+import re
+import subprocess
+
+from collections import namedtuple
+
+from . import utils
+
+
+def get_recommended_repo(path):
+    """Given vcs directory ``path``, returns the url from which the repo
+    can be cloned.
+
+    For git, an 'upstream' remote will be preferred over 'origin'.
+    For bzr, the :parent: branch will be preferred.
+    For hg, the 'default' alias will be preferred.
+
+    Returns None if the directory is not a repo, or a remote url can not
+    be determined.
+
+    :param path: A :class:`path.path` to a directory
+    :return: A url string, or None
+
+    """
+
+    Command = namedtuple("Command", "args parse")
+    cmds = [
+        Command(['git', 'remote', '-v'], _parse_git),
+        Command(['bzr', 'info'], _parse_bzr),
+        Command(['hg', 'paths'], _parse_hg),
+    ]
+
+    if not path.exists():
+        return None
+
+    with utils.cd(str(path)):
+        for cmd in cmds:
+            try:
+                output = subprocess.check_output(cmd.args)
+                if output:
+                    repo = cmd.parse(output)
+                    if repo:
+                        return repo
+            except subprocess.CalledProcessError:
+                continue
+
+
+def _parse_git(txt):
+    pat = re.compile(
+        r'(?P<name>\S+)\s+(?P<url>\S+)\s+\((?P<type>[^\)]+)\)')
+    urls = {}
+    for line in txt.split('\n'):
+        match = pat.search(line)
+        if match:
+            d = match.groupdict()
+            if d['name'] == 'upstream' and d['type'] == 'fetch':
+                return d['url'].strip()
+            elif d['type'] == 'fetch':
+                urls[d['name']] = d['url'].strip()
+
+    if 'origin' in urls:
+        return urls['origin']
+
+    for url in urls.values():
+        return url
+
+
+def _parse_bzr(txt):
+    pat = re.compile(r'parent branch: (?P<url>.*)')
+    for line in txt.split('\n'):
+        match = pat.search(line)
+        if match:
+            return match.groupdict()['url'].strip()
+
+
+def _parse_hg(txt):
+    pat = re.compile(r'(?P<name>[^\s]+) = (?P<url>.*)')
+    urls = []
+    for line in txt.split('\n'):
+        match = pat.search(line)
+        if match:
+            d = match.groupdict()
+            if d['name'] == 'default':
+                return d['url'].strip()
+            else:
+                urls.append(d['url'].strip())
+    return urls[0] if urls else None

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -31,7 +31,11 @@ class TestBuild(unittest.TestCase):
         bu.hide_metrics = True
         remove_layer_file = self.dirname / 'trusty/tester/to_remove'
         remove_layer_file.touch()
-        bu()
+        with mock.patch.object(build, 'log') as log:
+            bu()
+            log.warn.assert_called_with(
+                'Please add a `repo` key to your layer.yaml, '
+                'with a url from which your layer can be cloned.')
         base = path('out/trusty/foo')
         self.assertTrue(base.exists())
 

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -1,0 +1,260 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from charmtools.fetchers import (
+    BzrFetcher,
+    BzrMergeProposalFetcher,
+    GithubFetcher,
+    BitbucketFetcher,
+    LocalFetcher,
+    CharmstoreDownloader,
+    BundleDownloader,
+    rename,
+    normalize_bundle_name,
+)
+
+
+class RenameTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if os.path.exists(self.directory):
+            shutil.rmtree(self.directory)
+
+    def test_rename_no_meta(self):
+        self.assertEqual(rename(self.directory), self.directory)
+
+    def test_rename_no_name(self):
+        path = os.path.join(self.directory, "metadata.yaml")
+        with open(path, "w") as fp:
+            fp.write("another: key\n")
+        self.assertEqual(rename(self.directory), self.directory)
+
+    def test_rename_with_name(self):
+        d = tempfile.mkdtemp(dir=self.directory)
+        path = os.path.join(d, "metadata.yaml")
+        with open(path, "w") as fp:
+            fp.write("name: foo\n")
+        self.assertEqual(os.path.basename(rename(d)), "foo")
+
+
+class BzrFetcherTest(unittest.TestCase):
+    def test_can_fetch(self):
+        f = BzrFetcher.can_fetch
+
+        good_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo'),
+            f('launchpad:~tvansteenburgh/charms/precise/foo'),
+            f('http://launchpad.net/~tvansteenburgh/charms/precise/foo'),
+            f('https://launchpad.net/~tvansteenburgh/charms/precise/foo'),
+            f('http://www.launchpad.net/~tvansteenburgh/charms/precise/foo'),
+            f('https://www.launchpad.net/~tvansteenburgh/charms/precise/foo'),
+            f('http://code.launchpad.net/~tvansteenburgh/charms/precise/foo'),
+            f('https://code.launchpad.net/~tvansteenburgh/charms/precise/foo'),
+            f('bzr+ssh://bazaar.launchpad.net/~tvansteenburgh/charms/precise/foo'),
+        ]
+
+        bad_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo/+merge/12345'),
+            f('gh:charms/meteor'),
+            f('bb:charms/meteor'),
+            f('local:~/src/charms/precise/meteor'),
+            f('cs:precise/meteor'),
+            f('bundle:mediawiki/single'),
+        ]
+
+        for test in good_tests:
+            self.assertEqual(
+                test['repo'],
+                '~tvansteenburgh/charms/precise/foo')
+
+        for test in bad_tests:
+            self.assertEqual(test, {})
+
+
+class BzrMergeProposalFetcherTest(unittest.TestCase):
+    def test_can_fetch(self):
+        f = BzrMergeProposalFetcher.can_fetch
+
+        good_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo/+merge/12345'),
+        ]
+
+        bad_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo'),
+            f('gh:charms/meteor'),
+            f('bb:charms/meteor'),
+            f('local:~/src/charms/precise/meteor'),
+            f('cs:precise/meteor'),
+            f('bundle:mediawiki/single'),
+        ]
+
+        for test in good_tests:
+            self.assertEqual(
+                test['repo'],
+                '~tvansteenburgh/charms/precise/foo/+merge/12345')
+
+        for test in bad_tests:
+            self.assertEqual(test, {})
+
+
+class GithubFetcherTest(unittest.TestCase):
+    def test_can_fetch(self):
+        f = GithubFetcher.can_fetch
+
+        good_tests = [
+            f('gh:charms/meteor'),
+            f('github:charms/meteor'),
+            f('http://github.com/charms/meteor'),
+            f('https://github.com/charms/meteor'),
+            f('http://www.github.com/charms/meteor'),
+            f('https://www.github.com/charms/meteor'),
+            f('git@github.com:charms/meteor'),
+        ]
+
+        bad_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo'),
+            f('lp:~tvansteenburgh/charms/precise/foo/+merge/12345'),
+            f('bb:charms/meteor'),
+            f('local:~/src/charms/precise/meteor'),
+            f('cs:precise/meteor'),
+            f('bundle:mediawiki/single'),
+        ]
+
+        for test in good_tests:
+            self.assertEqual(test['repo'], 'charms/meteor')
+
+        for test in bad_tests:
+            self.assertEqual(test, {})
+
+
+class BitbucketFetcherTest(unittest.TestCase):
+    def test_can_fetch(self):
+        f = BitbucketFetcher.can_fetch
+
+        good_tests = [
+            f('bb:charms/meteor'),
+            f('bitbucket:charms/meteor'),
+            f('http://bitbucket.org/charms/meteor'),
+            f('https://bitbucket.org/charms/meteor'),
+            f('http://www.bitbucket.org/charms/meteor'),
+            f('https://www.bitbucket.org/charms/meteor'),
+        ]
+
+        bad_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo'),
+            f('lp:~tvansteenburgh/charms/precise/foo/+merge/12345'),
+            f('gh:charms/meteor'),
+            f('local:~/src/charms/precise/meteor'),
+            f('cs:precise/meteor'),
+            f('bundle:mediawiki/single'),
+        ]
+
+        for test in good_tests:
+            self.assertEqual(test['repo'], 'charms/meteor')
+
+        for test in bad_tests:
+            self.assertEqual(test, {})
+
+
+class LocalFetcherTest(unittest.TestCase):
+    def test_can_fetch(self):
+        f = LocalFetcher.can_fetch
+
+        good_tests = [
+            f('/tmp'),
+        ]
+
+        bad_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo'),
+            f('lp:~tvansteenburgh/charms/precise/foo/+merge/12345'),
+            f('gh:charms/meteor'),
+            f('bb:charms/meteor'),
+            f('cs:precise/meteor'),
+            f('bundle:mediawiki/single'),
+        ]
+
+        for test in good_tests:
+            self.assertEqual(test['path'], '/tmp')
+
+        for test in bad_tests:
+            self.assertEqual(test, {})
+
+
+class CharmstoreDownloaderTest(unittest.TestCase):
+    def test_can_fetch(self):
+        f = CharmstoreDownloader.can_fetch
+
+        good_tests = [
+            f('cs:precise/meteor'),
+        ]
+
+        bad_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo'),
+            f('lp:~tvansteenburgh/charms/precise/foo/+merge/12345'),
+            f('gh:charms/meteor'),
+            f('bb:charms/meteor'),
+            f('local:~/src/charms/precise/meteor'),
+            f('bundle:mediawiki/single'),
+        ]
+
+        for test in good_tests:
+            self.assertEqual(test['entity'], 'precise/meteor')
+
+        for test in bad_tests:
+            self.assertEqual(test, {})
+
+
+class BundleDownloaderTest(unittest.TestCase):
+    def test_can_fetch(self):
+        f = BundleDownloader.can_fetch
+
+        good_tests = [
+            f('bundle:mediawiki/single'),
+        ]
+
+        bad_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo'),
+            f('lp:~tvansteenburgh/charms/precise/foo/+merge/12345'),
+            f('gh:charms/meteor'),
+            f('bb:charms/meteor'),
+            f('local:~/src/charms/precise/meteor'),
+            f('cs:precise/meteor'),
+        ]
+
+        for test in good_tests:
+            self.assertEqual(test['entity'], 'mediawiki/single')
+
+        for test in bad_tests:
+            self.assertEqual(test, {})
+
+    def test_normalize_bundle_name(self):
+        f = normalize_bundle_name
+
+        inputs = [
+            '~charmers/mediawiki/6/single',
+            '~charmers/mediawiki/single',
+            'mediawiki/single',
+            'mediawiki/6/single',
+            'mediawiki-single',
+            'mediawiki-single-6',
+            '~charmers/mediawiki-single-6',
+            '~charmers/mediawiki-single',
+        ]
+
+        outputs = [
+            '~charmers/mediawiki-single-6',
+            '~charmers/mediawiki-single',
+            'mediawiki-single',
+            'mediawiki-single-6',
+            'mediawiki-single',
+            'mediawiki-single-6',
+            '~charmers/mediawiki-single-6',
+            '~charmers/mediawiki-single',
+        ]
+
+        for i, bundle_name in enumerate(inputs):
+            self.assertEqual(f(bundle_name), outputs[i])

--- a/tests/test_repofinder.py
+++ b/tests/test_repofinder.py
@@ -1,0 +1,43 @@
+import textwrap
+import unittest
+from charmtools import repofinder
+
+
+class TestRepoFinder(unittest.TestCase):
+
+    def test__parse_git(self):
+        s = textwrap.dedent("""\
+        origin  git@github.com:tvansteenburgh/charm-tools.git (fetch)
+        origin  git@github.com:tvansteenburgh/charm-tools.git (push)
+        upstream        git@github.com:juju/charm-tools-fetch.git (fetch)
+        upstream        git@github.com:juju/charm-tools.git (push)
+        """)
+        self.assertEqual(
+            repofinder._parse_git(s),
+            'git@github.com:juju/charm-tools-fetch.git'
+        )
+
+    def test__parse_hg(self):
+        s = textwrap.dedent("""\
+        default = https://tvansteenburgh@bitbucket.org/tvansteenburgh/loopy
+        """)
+        self.assertEqual(
+            repofinder._parse_hg(s),
+            'https://tvansteenburgh@bitbucket.org/tvansteenburgh/loopy'
+        )
+
+    def test__parse_bzr(self):
+        s = textwrap.dedent("""\
+        Standalone tree (format: 2a)
+        Location:
+          branch root: .
+
+        Related branches:
+            push branch: bzr+ssh://bazaar.launchpad.net/~tvansteenburgh/juju-deployer/1269783-force-terminate/
+          parent branch: bzr+ssh://bazaar.launchpad.net/+branch/juju-deployer/
+          submit branch: bzr+ssh://bazaar.launchpad.net/~bac/juju-deployer/update-store-url/
+        """)
+        self.assertEqual(
+            repofinder._parse_bzr(s),
+            'bzr+ssh://bazaar.launchpad.net/+branch/juju-deployer/'
+        )


### PR DESCRIPTION
Prints a WARN message if repo key is not present. If the top layer is in a vcs directory (git, bzr, or hg), will also provide a suggested repo url.