### PR TITLE
Make pull-source clone the charm's top layer if possible

### DIFF
--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -88,8 +88,7 @@ class InterfaceFetcher(fetchers.LocalFetcher):
         :return: 2-tuple of (:class:`Fetcher`, :class:`path`)
 
         """
-        # use the github fetcher for now
-        u = self.url[10:]
+        u = self.url[len(self.NAMESPACE) + 1:]
         f = get_fetcher(repo)
         if hasattr(f, "repo"):
             basename = path(f.repo).name.splitext()[0]

--- a/charmtools/fetchers.py
+++ b/charmtools/fetchers.py
@@ -258,6 +258,9 @@ class StoreCharm(object):
 
 
 class CharmstoreDownloader(Fetcher):
+    """Downloads and extracts a charm archive from the charm store.
+
+    """
     MATCH = re.compile(r"""
     ^cs:(?P<entity>.*)$
     """, re.VERBOSE)


### PR DESCRIPTION
If the charm is layered, and has a repo key set in layer.yaml, the top layer will be cloned. Otherwise, the charm will be downloaded from the charm store (cloned from bzr if possible, else archive downloaded and extracted).

Examples to test with:

`charm-pull-source cs:~tvansteenburgh/trusty/django-test-1 # layered, with repo key in layer.yaml`
`charm-pull-source cs:~marcoceppi/trusty/ubucon # layered, no repo key in layer.yaml`
`charm-pull-source cs:~tvansteenburgh/meteor-test # not layered`

