### PR TITLE
Add a generic git fetcher

### DIFF
--- a/charmtools/fetchers.py
+++ b/charmtools/fetchers.py
@@ -190,6 +190,22 @@ class GithubFetcher(Fetcher):
         return rename(dir_)
 
 
+class GitFetcher(Fetcher):
+    """Generic git fetcher.
+
+    Matches any url that starts with "git" or ends with ".git".
+
+    """
+    MATCH = re.compile(r"""
+    ^(?P<repo>git.*|.*\.git)?$
+    """, re.VERBOSE)
+
+    def fetch(self, dir_):
+        dir_ = tempfile.mkdtemp(dir=dir_)
+        git('clone {} {}'.format(self.repo, dir_))
+        return rename(dir_)
+
+
 class BitbucketFetcher(Fetcher):
     MATCH = re.compile(r"""
     ^(bb:|bitbucket:|https?://(www\.)?bitbucket.org/)
@@ -342,6 +358,7 @@ FETCHERS = [
     CharmstoreDownloader,
     BundleDownloader,
     LaunchpadGitFetcher,
+    GitFetcher,
 ]
 
 

--- a/charmtools/fetchers.py
+++ b/charmtools/fetchers.py
@@ -232,31 +232,6 @@ class LocalFetcher(Fetcher):
         return dst
 
 
-class StoreCharm(object):
-    STORE_URL = 'https://store.juju.ubuntu.com/charm-info'
-
-    def __init__(self, name):
-        self.name = name
-        self.data = self.fetch()
-
-    def __getattr__(self, key):
-        return self.data[key]
-
-    def fetch(self):
-        params = {
-            'stats': 0,
-            'charms': self.name,
-        }
-        r = get(self.STORE_URL, params=params).json()
-        charm_data = r[self.name]
-        if 'errors' in charm_data:
-            raise FetchError(
-                'Error retrieving "{}" from charm store: {}'.format(
-                    self.name, '; '.join(charm_data['errors']))
-            )
-        return charm_data
-
-
 class CharmstoreDownloader(Fetcher):
     """Downloads and extracts a charm archive from the charm store.
 

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -7,6 +7,7 @@ from charmtools.fetchers import (
     BzrFetcher,
     BzrMergeProposalFetcher,
     GithubFetcher,
+    GitFetcher,
     BitbucketFetcher,
     LocalFetcher,
     CharmstoreDownloader,
@@ -126,6 +127,31 @@ class GithubFetcherTest(unittest.TestCase):
 
         for test in good_tests:
             self.assertEqual(test['repo'], 'charms/meteor')
+
+        for test in bad_tests:
+            self.assertEqual(test, {})
+
+
+class GitFetcherTest(unittest.TestCase):
+    def test_can_fetch(self):
+        f = GitFetcher.can_fetch
+
+        good_tests = [
+            'git@foobar.com:charms/meteor',
+            'https://foobar.com/meteor.git',
+        ]
+
+        bad_tests = [
+            f('lp:~tvansteenburgh/charms/precise/foo'),
+            f('lp:~tvansteenburgh/charms/precise/foo/+merge/12345'),
+            f('bb:charms/meteor'),
+            f('local:~/src/charms/precise/meteor'),
+            f('cs:precise/meteor'),
+            f('bundle:mediawiki/single'),
+        ]
+
+        for test in good_tests:
+            self.assertEqual(f(test)['repo'], test)
 
         for test in bad_tests:
             self.assertEqual(test, {})


### PR DESCRIPTION
Lower match precedence than the site-specific Github and Launchpad fetchers. Will match any url that starts with "git" or ends with ".git".