### PR TITLE
Make all plugins handle --description

### DIFF
--- a/charmtools/build/__init__.py
+++ b/charmtools/build/__init__.py
@@ -570,11 +570,13 @@ def configLogging(build):
 
 def inspect(args=None):
     build = Builder()
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description='Inspect the layers of a built charm')
     parser.add_argument('-r', '--force-raw', action="store_true",
                         help="Force raw output (color)")
     parser.add_argument('-l', '--log-level', default=logging.INFO)
     parser.add_argument('charm', nargs="?", default=".", type=path)
+    utils.add_plugin_description(parser)
     # Namespace will set the options as attrs of build
     parser.parse_args(args, namespace=build)
     configLogging(build)
@@ -599,13 +601,18 @@ def deprecated_main():
         log_level = 'INFO'
 
     configLogging(MockBuild)
-    log.critical("{} has been deprecated, please use {}".format(old, new))
+
+    msg = "{} has been deprecated, please use {}".format(old, new)
+    if '--description' in sys.argv:
+        print(msg)
+    else:
+        log.critical(msg)
 
 
 def main(args=None):
     build = Builder()
     parser = argparse.ArgumentParser(
-        description="Build a charm from layers and interfaces.",
+        description="Build a charm from layers and interfaces",
         formatter_class=argparse.RawDescriptionHelpFormatter,)
     parser.add_argument('-l', '--log-level', default=logging.INFO)
     parser.add_argument('-f', '--force', action="store_true")
@@ -620,6 +627,7 @@ def main(args=None):
     parser.add_argument('-r', '--report', action="store_true",
                         help="Show post-build report of changes")
     parser.add_argument('charm', nargs="?", default=".", type=path)
+    utils.add_plugin_description(parser)
     # Namespace will set the options as attrs of build
     parser.parse_args(args, namespace=build)
     if build.charm == "help":

--- a/charmtools/cli.py
+++ b/charmtools/cli.py
@@ -13,7 +13,9 @@ def parser_defaults(parser):
 
 
 def usage(exit_code=0, bundle=False):
-    sys.stderr.write('usage: %s subcommand\n' % os.path.basename(sys.argv[0]))
+    sys.stderr.write(
+        'Get help for a charm subcommand\n\n'
+        'usage: %s subcommand\n' % os.path.basename(sys.argv[0]))
     subs = subcommands(os.path.dirname(os.path.realpath(__file__)))
     sys.stderr.write('\n  Available subcommands are:\n    ')
     sys.stderr.write('\n    '.join(subs))

--- a/charmtools/create.py
+++ b/charmtools/create.py
@@ -28,6 +28,7 @@ from charmtools.generators import (
     CharmGeneratorException,
     get_installed_templates,
 )
+from . import utils
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +36,8 @@ DEFAULT_TEMPLATE = 'reactive-python'
 
 
 def setup_parser():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description='Create a new charm')
 
     parser.add_argument(
         'charmname',
@@ -60,6 +62,7 @@ def setup_parser():
         help='Print debug information',
         action='store_true', default=False,
     )
+    utils.add_plugin_description(parser)
 
     return parser
 

--- a/charmtools/generate.py
+++ b/charmtools/generate.py
@@ -24,6 +24,7 @@ from Cheetah.Template import Template
 from cli import parser_defaults
 from charms import Charm
 from charmworldlib.charm import Charms
+from . import utils
 
 TPL_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')
 CHARM_TPL = os.path.join(TPL_DIR, 'charm')
@@ -100,9 +101,10 @@ sudo apt-get install amulet python3-requests -y
 
 def parser(args=None):
     parser = argparse.ArgumentParser(
-        description='Builds portions of a charm or bundle')
+        description='Add icon, readme, or tests to a charm')
     parser.add_argument('subcommand', choices=['tests', 'readme', 'icon'],
                         help='Which type of generator to run')
+    utils.add_plugin_description(parser)
     parser = parser_defaults(parser)
     return parser.parse_known_args(args)
 

--- a/charmtools/proof.py
+++ b/charmtools/proof.py
@@ -22,11 +22,12 @@ import argparse
 from bundles import Bundle
 from charms import Charm
 from cli import parser_defaults
+from . import utils
 
 
 def get_args(args=None):
     parser = argparse.ArgumentParser(
-        description='Performs static analysis on charms and bundles')
+        description='Perform static analysis on a charm or bundle')
     parser.add_argument('-n', '--offline', action='store_false',
                         help='Only perform offline proofing')
     parser.add_argument('--server', default=None,
@@ -37,6 +38,7 @@ def get_args(args=None):
                         help=argparse.SUPPRESS)
     parser.add_argument('charm_name', nargs='?', default=os.getcwd(),
                         help='path of charm dir to check. Defaults to PWD')
+    utils.add_plugin_description(parser)
     parser = parser_defaults(parser)
     args = parser.parse_args(args)
 

--- a/charmtools/pullsource.py
+++ b/charmtools/pullsource.py
@@ -18,7 +18,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Downloads the source code for a charm, layer, or interface.
+"""Download the source code for a charm, layer, or interface.
 
 The item to download can be specified using any of the following forms:
 
@@ -58,6 +58,7 @@ import textwrap
 
 import yaml
 
+from . import utils
 from .build import fetchers
 from fetchers import (
     CharmstoreDownloader,
@@ -207,6 +208,7 @@ def setup_parser():
         help='Show verbose output',
         action='store_true', default=False,
     )
+    utils.add_plugin_description(parser)
 
     return parser
 

--- a/charmtools/test.py
+++ b/charmtools/test.py
@@ -567,7 +567,7 @@ def setup_parser():
     parser = argparse.ArgumentParser(
         prog='juju test',
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description='Execute a charms functional tests',
+        description='Execute charm functional tests',
         epilog="""\
 `%(prog)s` should always be run from within a CHARM_DIR.
 

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -1,3 +1,4 @@
+import argparse
 import copy
 import collections
 import hashlib
@@ -524,3 +525,14 @@ def delta_python_dump(orig, dest, patterns=REACTIVE_PATTERNS,
                    m=message)
         i += 1
     return i == 0
+
+
+class Description(argparse._StoreTrueAction):
+    """A argparse action that prints its parent parser's description and exits."""
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(parser.description.split('\n')[0].strip('. '))
+        raise SystemExit()
+
+
+def add_plugin_description(parser):
+    parser.add_argument('--description', action=Description)


### PR DESCRIPTION
```
(.venv) 148 tvansteenburgh@xenial-vm:~/src/charm-tools⟫ charm help plugins
charm plugins

Plugins are implemented as stand-alone executable files somewhere in the user's PATH.
The executable command must be of the format charm-<plugin name>.

add          Add icon, readme, or tests to a charm
build        Build a charm from layers and interfaces
compose      compose has been deprecated, please use build
create       Create a new charm
help         Get help for a charm subcommand
layers       Inspect the layers of a built charm
proof        Perform static analysis on a charm or bundle
pull-source  Download the source code for a charm, layer, or interface
test         Execute charm functional tests
version      charm-tools 2.0a1
```

Fixes #137 