### PR TITLE
Replace charmworldlib with libcharmstore

### DIFF
--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -243,7 +243,7 @@ class Charm(object):
     def is_charm(self):
         return os.path.isfile(os.path.join(self.charm_path, 'metadata.yaml'))
 
-    def proof(self, remote=True, **kw):
+    def proof(self):
         lint = CharmLinter()
         charm_name = self.charm_path
         if os.path.isdir(charm_name):

--- a/charmtools/generate.py
+++ b/charmtools/generate.py
@@ -23,7 +23,8 @@ from Cheetah.Template import Template
 
 from cli import parser_defaults
 from charms import Charm
-from charmworldlib.charm import Charms
+from charmstore import CharmStore
+from charmstore.error import CharmNotFound
 from . import utils
 
 TPL_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')
@@ -31,9 +32,17 @@ CHARM_TPL = os.path.join(TPL_DIR, 'charm')
 
 
 def graph(interface, endpoint, series='trusty'):
-    matches = {'requires': 'provides', 'provides': 'requires'}
-    c = Charms()
-    charms = c.search({matches[endpoint]: interface, 'series': series})
+    matches = {
+        'requires': 'provides',
+        'provides': 'requires',
+    }
+    match = matches[endpoint]
+    c = CharmStore()
+    try:
+        charms = getattr(c, match)(interface)
+    except CharmNotFound:
+        return None
+    charms = [c for c in charms if c.series == series]
     if charms:
         return charms[0]
     else:

--- a/charmtools/get.py
+++ b/charmtools/get.py
@@ -19,7 +19,7 @@ import sys
 import argparse
 
 from mr import Mr
-from charmworldlib import charm as cwc
+from charmstore import Charm
 
 
 def setup_parser():
@@ -39,7 +39,7 @@ def parse_charm_id(charm_id):
         charm_id = charm_id.replace('cs:', '')
 
     try:
-        charm = cwc.Charm(charm_id)
+        charm = Charm(charm_id)
     except:
         return None
 

--- a/charmtools/info.py
+++ b/charmtools/info.py
@@ -19,11 +19,11 @@ import re
 import argparse
 
 from cli import parser_defaults
-from charmworldlib import charm
+from charmstore import Charm
 
 
 def info(charm_id, is_bundle=False):
-    c = charm.Charm(charm_id)
+    c = Charm(charm_id)
     readme = [s for s in c.files if re.match("^readme", s, re.IGNORECASE)]
 
     if not readme:

--- a/charmtools/proof.py
+++ b/charmtools/proof.py
@@ -22,20 +22,12 @@ import argparse
 from bundles import Bundle
 from charms import Charm
 from cli import parser_defaults
-from . import utils
+from charmtools import utils
 
 
 def get_args(args=None):
     parser = argparse.ArgumentParser(
         description='Perform static analysis on a charm or bundle')
-    parser.add_argument('-n', '--offline', action='store_false',
-                        help='Only perform offline proofing')
-    parser.add_argument('--server', default=None,
-                        help=argparse.SUPPRESS)
-    parser.add_argument('--port', default=None, type=int,
-                        help=argparse.SUPPRESS)
-    parser.add_argument('--secure', action='store_true',
-                        help=argparse.SUPPRESS)
     parser.add_argument('charm_name', nargs='?', default=os.getcwd(),
                         help='path of charm dir to check. Defaults to PWD')
     utils.add_plugin_description(parser)
@@ -45,7 +37,7 @@ def get_args(args=None):
     return args
 
 
-def proof(path, is_bundle, with_remote, debug, server, port, secure):
+def proof(path, is_bundle, debug):
     path = os.path.abspath(path)
     if not is_bundle:
         try:
@@ -61,18 +53,15 @@ def proof(path, is_bundle, with_remote, debug, server, port, secure):
         except Exception as e:
             return ["FATAL: %s" % e.message], 200
 
-    lint, err_code = c.proof(
-        remote=with_remote, server=server, port=port, secure=secure)
+    lint, err_code = c.proof()
     return lint, err_code
 
 
 def main():
     args_ = get_args()
-    lint, exit_code = proof(args_.charm_name, args_.bundle, args_.offline,
-                            args_.debug, args_.server, args_.port,
-                            args_.secure)
+    lint, exit_code = proof(args_.charm_name, args_.bundle, args_.debug)
     if lint:
-        print "\n".join(lint)
+        print("\n".join(lint))
     sys.exit(exit_code)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML==3.11
 blessings==1.6
 bzr>=2.6.0
-libcharmstore>=0.0.2
+libcharmstore>=0.0.3
 cheetah==2.4.4
 colander==1.0
 coverage==3.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML==3.11
 blessings==1.6
 bzr>=2.6.0
-charmworldlib>=0.4.2
+libcharmstore>=0.0.2
 cheetah==2.4.4
 colander==1.0
 coverage==3.7.1
@@ -18,7 +18,7 @@ otherstuf==1.1.0
 path.py==8.1.2
 pathspec==0.3.3
 pip>=7.1.2
-requests==2.7.0
+requests==2.6.0
 responses==0.4.0
 ruamel.yaml==0.10.2
 virtualenv>=1.11.4

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=['launchpadlib', 'argparse', 'cheetah', 'pyyaml',
                       'pycrypto', 'paramiko', 'requests',
-                      'charmworldlib', 'blessings', 'ruamel.yaml',
+                      'libcharmstore', 'blessings', 'ruamel.yaml',
                       'pathspec', 'otherstuf', 'path.py', 'pip',
                       'jujubundlelib', 'virtualenv', 'colander',
                       'jsonschema'],

--- a/tests/test_bundle_proof.py
+++ b/tests/test_bundle_proof.py
@@ -16,11 +16,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import charmtools.bundles
-import os.path
-import shutil
-import sys
-import tempfile
-import textwrap
 import unittest
 
 
@@ -35,9 +30,10 @@ class TestCharmProof(unittest.TestCase):
                     'charm': 'cs:precise/memcached',
                     'num_units': 1,
                 },
-            }}, 'my-service')
+            }
+        })
         self.assertIn(
-            'W: my-service: memcached: charm URL should include a revision',
+            'W: memcached: charm URL should include a revision',
             self.linter.lint)
 
     def test_no_warning_when_charm_urls_include_revisions(self):
@@ -47,7 +43,8 @@ class TestCharmProof(unittest.TestCase):
                     'charm': 'cs:precise/memcached-99',
                     'num_units': 1,
                 },
-            }}, 'my-service')
+            }
+        })
         self.assertNotIn(
             'W: memcached: charm URL should include a revision',
             self.linter.lint)
@@ -59,10 +56,11 @@ class TestCharmProof(unittest.TestCase):
                     'charm': 'cs:precise/memcached',
                     'num_units': 1,
                 },
-            }}, 'my-service')
+            }
+        })
         self.assertIn(
-            'W: my-service: memcached: No annotations found, will render '
-                'poorly in GUI',
+            'W: memcached: No annotations found, will render '
+            'poorly in GUI',
             self.linter.lint)
 
     def test_no_warning_when_annotations_are_included(self):
@@ -81,5 +79,5 @@ class TestCharmProof(unittest.TestCase):
             }})
         self.assertNotIn(
             'W: my-service: memcached: No annotations found, will render '
-                'poorly in GUI',
+            'poorly in GUI',
             self.linter.lint)

--- a/tests/test_charm_generate.py
+++ b/tests/test_charm_generate.py
@@ -3,25 +3,24 @@ from charmtools.generate import (
     graph,
     copy_file,
 )
-from mock import patch
+from mock import patch, Mock
 
 
 class JujuCharmAddTest(unittest.TestCase):
-    @patch('charmtools.generate.Charms')
-    def test_graph(self, mcharm):
-        m = mcharm.return_value
-        m.search.return_value = [{'foo': 'bar'}]
-        self.assertEqual(graph('nagios', 'requires'), {'foo': 'bar'})
-        m.search.assert_called_with({'series': 'trusty',
-                                     'provides': 'nagios'})
+    @patch('charmtools.generate.CharmStore')
+    def test_graph(self, store):
+        charm = Mock(series='trusty')
+        store = store.return_value
+        store.provides.return_value = [charm]
+        self.assertEqual(graph('nagios', 'requires'), charm)
+        store.provides.assert_called_with('nagios')
 
-    @patch('charmtools.generate.Charms')
-    def test_graph_no_interface(self, mcharm):
-        m = mcharm.return_value
-        m.search.return_value = None
+    @patch('charmtools.generate.CharmStore')
+    def test_graph_no_interface(self, store):
+        store = store.return_value
+        store.provides.return_value = []
         self.assertEqual(graph('nointerface', 'requires'), None)
-        m.search.assert_called_with({'series': 'trusty',
-                                     'provides': 'nointerface'})
+        store.provides.assert_called_with('nointerface')
 
     @patch('charmtools.generate.Charm')
     def test_not_charm(self, mcharm):


### PR DESCRIPTION
- Removed all the remote proofing stuff. Now we just proof
  locally with jujubundlelib, with some of our own checks
  on top.
- Had to pin requests at 2.6.0 b/c theblues, a dep of
  libcharmstore, requires that specific version.
- Integration tests ('make check') all pass.

Fixes #144.