### PR TITLE
Better feedback to user when command fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ man
 .ropeproject/
 .tox/
 *.pyc
+*.sw[nop]
+.venv/

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -550,7 +550,7 @@ class InstallerTactic(Tactic):
                            "install",
                            "--user",
                            "--ignore-installed",
-                           spec), env=localenv).throw_on_error()()
+                           spec), env=localenv).exit_on_error()()
             self._tracked = []
             # We now manage two classes of explicit mappings
             # When python packages are installed into a prefix
@@ -619,7 +619,7 @@ class WheelhouseTactic(ExactMatch, Tactic):
             utils.Process((pip, 'install',
                            '--no-binary', ':all:',
                            '-d', temp_dir) +
-                          reqs).throw_on_error()()
+                          reqs).exit_on_error()()
             for wheel in temp_dir.files():
                 dest = wheelhouse / wheel.basename()
                 dest.remove_p()
@@ -633,8 +633,8 @@ class WheelhouseTactic(ExactMatch, Tactic):
         wheelhouse = self.target.directory / 'wheelhouse'
         wheelhouse.mkdir_p()
         if create_venv:
-            utils.Process(('virtualenv', '--python', 'python3', venv)).throw_on_error()()
-            utils.Process((pip, 'install', '-U', 'pip', 'wheel')).throw_on_error()()
+            utils.Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()
+            utils.Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
         for tactic in self.previous:
             tactic(venv)
         self._add(pip, wheelhouse, '-r', self.entity)

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -152,7 +152,7 @@ class ProcessResult(object):
 
     __nonzero__ = __bool__
 
-    def throw_on_error(self):
+    def exit_on_error(self):
         if not bool(self):
             sys.stderr.write(
                 '{}\n\nCommand failed: {}\n'.format(self.output, self.cmd))
@@ -160,19 +160,19 @@ class ProcessResult(object):
 
 
 class Process(object):
-    def __init__(self, command=None, throw=False, log=log, **kwargs):
+    def __init__(self, command=None, exit=False, log=log, **kwargs):
         if isinstance(command, str):
             command = (command, )
         self.command = command
-        self._throw_on_error = False
+        self._exit_on_error = exit
         self.log = log
         self._kw = kwargs
 
     def __repr__(self):
         return "<Command %s>" % (self.command, )
 
-    def throw_on_error(self, throw=True):
-        self._throw_on_error = throw
+    def exit_on_error(self, exit=True):
+        self._exit_on_error = exit
         return self
 
     def __call__(self, *args, **kw):
@@ -198,8 +198,8 @@ class Process(object):
         exit_code = p.poll()
         result = ProcessResult(all_args, exit_code, stdout, stderr)
         self.log.debug("process: %s (%d)", result.cmd, result.exit_code)
-        if self._throw_on_error:
-            result.throw_on_error()
+        if self._exit_on_error:
+            result.exit_on_error()
         return result
 
 command = Process
@@ -217,7 +217,7 @@ class Commander(object):
 
     def check(self, *args, **kwargs):
         kwargs.update({'log': self.log})
-        return command(command=args, **kwargs).throw_on_error()
+        return command(command=args, **kwargs).exit_on_error()
 
     def __call__(self, *args, **kwargs):
         kwargs.update({'log': self.log})

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -154,8 +154,9 @@ class ProcessResult(object):
 
     def throw_on_error(self):
         if not bool(self):
-            raise subprocess.CalledProcessError(
-                self.exit_code, self.command, output=self.output)
+            sys.stderr.write(
+                '{}\n\nCommand failed: {}\n'.format(self.output, self.cmd))
+            sys.exit(self.exit_code)
 
 
 class Process(object):


### PR DESCRIPTION
Instead of raising a CalledProcessError, write the output of the failed
command, and the command itself, to stderr, then exit with the exit
code of the failed command.

Fixes #126.