### PR TITLE
Don't build multi-series charms into a series dir

### DIFF
--- a/charmtools/build/__init__.py
+++ b/charmtools/build/__init__.py
@@ -203,7 +203,7 @@ class Builder(object):
     def create_repo(self):
         # Generated output will go into this directory
         base = path(self.output_dir)
-        self.repo = (base / self.series if self.series else base)
+        self.repo = (base / (self.series if self.series else 'builds'))
         # And anything it includes from will be placed here
         # outside the series
         self.deps = (base / "deps")


### PR DESCRIPTION
- If no series given on cmd line and charm is multi-series
  ('series' key in metadata.yaml), don't build in a series dir.
- If no series given on cmd line and charm is not multi-series,
  build in default series dir.
- Added new log.info to show the final destination dir of the
  built charm.
- 'charm_name' property and 'warnings' import removed b/c
  not used anywhere.

Fixes #115.