### PR TITLE
Enable interface.yaml ignore config option

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -156,7 +156,8 @@ class InterfaceCopy(Tactic):
         # directory
         log.debug("Copying Interface %s: %s",
                   self.interface.name, self.target)
-        ignorer = utils.ignore_matcher(self.config.ignores)
+        ignorer = utils.ignore_matcher(self.config.ignores +
+                                       self.interface.config.ignores)
         for entity, _ in utils.walk(self.interface.directory,
                                     lambda x: True,
                                     matcher=ignorer,


### PR DESCRIPTION
This change pulls through an ignore specs in the ignore config file in
the interface.yaml file.

Fixes #192 interfaces.yaml ignore option doesn't have any effect
with charm build