### PR TITLE
add payloads to metadata known keys fixes #196

### DIFF
--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -29,6 +29,7 @@ KNOWN_METADATA_KEYS = [
     'series',
     'storage',
     'extra-bindings',
+    'payloads',
 ]
 
 KNOWN_RELATION_KEYS = ['interface', 'scope', 'limit', 'optional']

--- a/tests_functional/charms/unknown-metadata/metadata.yaml
+++ b/tests_functional/charms/unknown-metadata/metadata.yaml
@@ -18,3 +18,8 @@ peers:
   relation-name:
     interface: interface-name
   non-map: [ interface, interface-name ]
+payloads:
+  testy:
+    type: toot
+  toot:
+    type: kvm

--- a/tests_functional/proof/expected/unknown-metadata
+++ b/tests_functional/proof/expected/unknown-metadata
@@ -1,5 +1,6 @@
 E: Unknown root metadata field (foo)
 I: metadata name (test) must match directory name (unknown-metadata) exactly for local deployment.
+E: payloads.testy.type: "toot" is not one of kvm, docker
 W: no copyright file
 W: Includes template README.ex file
 W: README.ex includes boilerplate: Describe the intended usage of this charm and anything unique about how this charm relates to others here.


### PR DESCRIPTION
Adds integration tests for payloads key and adds payloads to the KNOWN_METADATA_KEYS list

## Checklist

 - [X] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [X] Are all your commits [logically] grouped and squashed appropriately?
 - [X] Does this patch have code coverage?
 - [X] Does your code pass `make test`?

