### PR TITLE
Limit paramiko to releases prior to 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=['launchpadlib', 'argparse', 'cheetah', 'pyyaml',
-                      'pycrypto', 'paramiko', 'requests',
+                      'pycrypto', 'paramiko<2.0.0', 'requests',
                       'charmworldlib', 'blessings', 'ruamel.yaml',
                       'pathspec', 'otherstuf', 'path.py', 'pip',
                       'jujubundlelib', 'virtualenv', 'colander',


### PR DESCRIPTION
Paramiko released a new version in the last 24 hrs that introduces a new dependency on cryptography, which in a trusty virtualenv causes a version mismatch and test error in charm-tools itself and across all of the OpenStack charms due to a requirement for newer setuptools and virtualenv installs.

If we can limit the upper bound in charm-tools, we effectively resolve this in one place, rather than 56 charms (master and stable branches are all broken right now).
