### PR TITLE
Fix the order of fetch vs append (fixes #218)

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -284,8 +284,9 @@ class Builder(object):
                 base_layer = Layer(base, self.deps)
                 if base_layer.name in [i.name for i in results['layers']]:
                     continue
-                results["layers"].append(base_layer.fetch())
+                base_layer.fetch()
                 self.fetch_dep(base_layer, results)
+                results["layers"].append(base_layer)
 
     def build_tactics(self, entry, current, config, output_files):
         # Delegate to the config object, it's rules

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -80,11 +80,15 @@ class TestBuild(unittest.TestCase):
         self.assertIn("numeric-string", config_data)
         default_value = config_data['numeric-string']['default']
         self.assertEqual(default_value, "0123456789", "value must be a string")
+        # Issue 218, ensure proper order of layer application
+        self.assertEqual(config_data['backup_retention_count']['default'], 7,
+                         'Config from layers was merged in wrong order')
 
         cyaml = base / "layer.yaml"
         self.assertTrue(cyaml.exists())
         cyaml_data = yaml.load(cyaml.open())
-        self.assertEquals(cyaml_data['includes'], ['trusty/mysql'])
+        self.assertEquals(cyaml_data['includes'], ['trusty/test-base',
+                                                   'trusty/mysql'])
         self.assertEquals(cyaml_data['is'], 'foo')
         self.assertEquals(cyaml_data['options']['trusty/mysql']['qux'], 'one')
 

--- a/tests/trusty/mysql/layer.yaml
+++ b/tests/trusty/mysql/layer.yaml
@@ -1,3 +1,4 @@
+includes: ['trusty/test-base']
 defines:
   qux:
     enum: ['one', 'two']

--- a/tests/trusty/test-base/config.yaml
+++ b/tests/trusty/test-base/config.yaml
@@ -1,0 +1,5 @@
+options:
+    backup_retention_count:
+        default: 0
+        type: int
+        description: Number of recent backups to retain.


### PR DESCRIPTION
Fixes #218 by ensuring that a layers deps are (recursively) appended to the list before itself.  This fixes a regression from 87c26dc4

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?

