### PR TITLE
Adding de-duplication for lists in metadata.yaml

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -187,7 +187,7 @@ class InterfaceCopy(Tactic):
     def lint(self):
         impl = self.interface.directory / self.role + '.py'
         if not impl.exists():
-            log.error('Missing implementation for interface role: %s.py', self.role)
+            log.error('Missing implementation for interface role: %s.py', self.role)  # noqa
             return False
         valid = True
         for entry in self.interface.directory.walkfiles():
@@ -220,7 +220,7 @@ class DynamicHookBind(Tactic):
         for target in self.targets:
             target.parent.makedirs_p()
             target.write_text(template.format(self.name))
-            target.chmod(0755)
+            target.chmod(0o755)
 
     def sign(self):
         """return sign in the form {relpath: (origin layer, SHA256)}
@@ -371,8 +371,8 @@ class LayerYAML(YAMLTactic):
         layer "foo" defining ``bar: {type: string}`` will accept
         ``options: {foo: {bar: "foo"}}`` in the final ``layer.yaml``.
 
-      * ``options`` This object can contain option name/value sections for other
-        layers.  For example, if the current layer includes the previously
+      * ``options`` This object can contain option name/value sections for
+        other layers. For example, if the current layer includes the previously
         referenced "foo" layer, it could include ``foo: {bar: "foo"}`` in its
         ``options`` section.
 
@@ -423,10 +423,10 @@ class LayerYAML(YAMLTactic):
                 s='s' if len(unknown_layer_names) > 1 else '',
                 layers=', '.join(unknown_layer_names)))
             return False
-        validator = extend_with_default(jsonschema.Draft4Validator)(self.schema)
+        validator = extend_with_default(jsonschema.Draft4Validator)(self.schema)  # noqa
         valid = True
         for error in validator.iter_errors(self.data['options']):
-            log.error('Invalid value for option %s: %s', '.'.join(error.absolute_path), error.message)
+            log.error('Invalid value for option %s: %s', '.'.join(error.absolute_path), error.message)  # noqa
             valid = False
         return valid
 
@@ -470,15 +470,17 @@ class MetadataYAML(YAMLTactic):
     """Rule Driven metadata.yaml generation"""
     section = "metadata"
     FILENAME = "metadata.yaml"
-    KEY_ORDER = ["name",
-                 "summary",
-                 "maintainer",
-                 "maintainers",
-                 "description",
-                 "tags",
-                 "requires",
-                 "provides",
-                 "peers"]
+    KEY_ORDER = [
+        "name",
+        "summary",
+        "maintainer",
+        "maintainers",
+        "description",
+        "tags",
+        "requires",
+        "provides",
+        "peers",
+    ]
 
     def __init__(self, *args, **kwargs):
         super(MetadataYAML, self).__init__(*args, **kwargs)
@@ -518,7 +520,6 @@ class MetadataYAML(YAMLTactic):
             if '.' in name:
                 continue
             self.storage.pop(name, None)
-
 
     def dump(self, data):
         final = yaml.comments.CommentedMap()
@@ -645,7 +646,7 @@ class WheelhouseTactic(ExactMatch, Tactic):
         self.previous = []
 
     def __str__(self):
-        return "Building wheelhouse in {}".format(self.target.directory / 'wheelhouse')
+        return "Building wheelhouse in {}".format(self.target.directory / 'wheelhouse')  # noqa
 
     def combine(self, existing):
         self.previous = existing.previous + [existing]
@@ -671,8 +672,8 @@ class WheelhouseTactic(ExactMatch, Tactic):
         wheelhouse = self.target.directory / 'wheelhouse'
         wheelhouse.mkdir_p()
         if create_venv:
-            utils.Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()
-            utils.Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
+            utils.Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()  # noqa
+            utils.Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()  # noqa
         for tactic in self.previous:
             tactic(venv)
         self._add(pip, wheelhouse, '-r', self.entity)

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -187,7 +187,8 @@ class InterfaceCopy(Tactic):
     def lint(self):
         impl = self.interface.directory / self.role + '.py'
         if not impl.exists():
-            log.error('Missing implementation for interface role: %s.py', self.role)  # noqa
+            log.error('Missing implementation for interface role: %s.py',
+                      self.role)
             return False
         valid = True
         for entry in self.interface.directory.walkfiles():
@@ -423,10 +424,12 @@ class LayerYAML(YAMLTactic):
                 s='s' if len(unknown_layer_names) > 1 else '',
                 layers=', '.join(unknown_layer_names)))
             return False
-        validator = extend_with_default(jsonschema.Draft4Validator)(self.schema)  # noqa
+        validator = extend_with_default(
+            jsonschema.Draft4Validator)(self.schema)
         valid = True
         for error in validator.iter_errors(self.data['options']):
-            log.error('Invalid value for option %s: %s', '.'.join(error.absolute_path), error.message)  # noqa
+            log.error('Invalid value for option %s: %s',
+                      '.'.join(error.absolute_path), error.message)
             valid = False
         return valid
 
@@ -646,7 +649,8 @@ class WheelhouseTactic(ExactMatch, Tactic):
         self.previous = []
 
     def __str__(self):
-        return "Building wheelhouse in {}".format(self.target.directory / 'wheelhouse')  # noqa
+        directory = self.target.directory / 'wheelhouse'
+        return "Building wheelhouse in {}".format(directory)
 
     def combine(self, existing):
         self.previous = existing.previous + [existing]
@@ -672,8 +676,10 @@ class WheelhouseTactic(ExactMatch, Tactic):
         wheelhouse = self.target.directory / 'wheelhouse'
         wheelhouse.mkdir_p()
         if create_venv:
-            utils.Process(('virtualenv', '--python', 'python3', venv)).exit_on_error()()  # noqa
-            utils.Process((pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()  # noqa
+            utils.Process(
+                ('virtualenv', '--python', 'python3', venv)).exit_on_error()()
+            utils.Process(
+                (pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
         for tactic in self.previous:
             tactic(venv)
         self._add(pip, wheelhouse, '-r', self.entity)

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -46,17 +46,21 @@ def tempdir(chdir=True):
 
 def deepmerge(dest, src):
     """
-    Deep merge of two dicts.
+    Deep merge all the keys in src. When the value of the key is a dict,
+    recursively call deepmerge. When the value of the key is a list, iterate
+    the entire list and de-duplicate the list. When neither a dict or a list
+    call the python copy.deepcopy method.
 
-    This is destructive (`dest` is modified), but values
-    from `src` are passed through `copy.deepcopy`.
+    This is destructive (`dest` is modified), as values from `src` may be
+    passed through `copy.deepcopy`.
     """
     for k, v in src.iteritems():
         if dest.get(k) and isinstance(v, dict):
             deepmerge(dest[k], v)
         elif dest.get(k) and isinstance(v, list):
-            if not v in dest.get(k):
-                dest[k].extend(v)
+            for item in v:
+                if item not in dest[k]:
+                    dest[k].append(item)
         else:
             dest[k] = copy.deepcopy(v)
     return dest

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -67,6 +67,12 @@ class TestBuild(unittest.TestCase):
         metadata_data = yaml.load(metadata.open())
         self.assertIn("shared-db", metadata_data['provides'])
         self.assertIn("storage", metadata_data['provides'])
+        # The maintainer, maintainers values should only be from the top layer.
+        self.assertIn("maintainer", metadata_data)
+        self.assertEqual(metadata_data['maintainer'], "Tester <test@er.com>")
+        self.assertNotIn("maintainers", metadata_data)
+        # The tags list must be de-duplicated.
+        self.assertEqual(metadata_data['tags'], ["databases"])
 
         # Config should have keys but not the ones in deletes
         config = base / "config.yaml"
@@ -114,7 +120,7 @@ class TestBuild(unittest.TestCase):
         self.assertEquals(data["signatures"]['metadata.yaml'], [
             u'foo',
             "dynamic",
-            u'0d7519db7301acb8efbd4f88bab5bc0a1b927842cffeab99404aa7a4dc03d17d'
+            u'5691b0c0aaf43d0f27d8eca6afbd1145aa3f4307456757e592827f002cf603f2'
             ])
 
         storage_attached = base / "hooks/data-storage-attached"

--- a/tests/trusty/mysql/metadata.yaml
+++ b/tests/trusty/mysql/metadata.yaml
@@ -1,12 +1,15 @@
 name: mysql
 summary: MySQL is a fast, stable and true multi-user, multi-threaded SQL database
 maintainer: Marco Ceppi <marco@ceppi.net>
+maintainers:
+  - Matthew Bruzek <matthew.bruzek@canonical.com>
+  - Marco Ceppi <marco@ceppi.net>
 description: |
   MySQL is a fast, stable and true multi-user, multi-threaded SQL database
   server. SQL (Structured Query Language) is the most popular database query
   language in the world. The main goals of MySQL are speed, robustness and
   ease of use.
-categories:
+tags:
     - databases
 provides:
   db:

--- a/tests/trusty/tester/metadata.yaml
+++ b/tests/trusty/tester/metadata.yaml
@@ -1,12 +1,12 @@
 name: tester
 summary: An imagined extension to the mysql charm
-maintainer: None
+maintainer: Tester <test@er.com>
 description: |
   MySQL is a fast, stable and true multi-user, multi-threaded SQL database
   server. SQL (Structured Query Language) is the most popular database query
   language in the world. The main goals of MySQL are speed, robustness and
   ease of use.
-categories:
+tags:
     - databases
 provides:
   storage:


### PR DESCRIPTION

Also adding special case for 'maintainer' and 'maintainers' keys
in metadata.yaml where the only the top layer maintainers are
listed in the built artifact.

## Checklist

 - [ ] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?

