### PR TITLE
Pinning the ruamel.yaml version in setup.py same as requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pathspec==0.3.4
 pip>=7.1.2
 requests==2.9.1
 responses==0.3.0
-ruamel.yaml==0.10.23
+ruamel.yaml==0.11.14
 virtualenv>=1.11.4
 jsonschema==2.5.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=['launchpadlib', 'argparse', 'cheetah', 'pyyaml',
                       'pycrypto', 'paramiko<2.0.0', 'requests',
-                      'libcharmstore', 'blessings', 'ruamel.yaml',
+                      'libcharmstore', 'blessings', 'ruamel.yaml==0.10.23',
                       'pathspec', 'otherstuf', 'path.py', 'pip',
                       'jujubundlelib', 'virtualenv', 'colander',
                       'jsonschema'],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=['launchpadlib', 'argparse', 'cheetah', 'pyyaml',
                       'pycrypto', 'paramiko<2.0.0', 'requests',
-                      'libcharmstore', 'blessings', 'ruamel.yaml==0.10.23',
+                      'libcharmstore', 'blessings', 'ruamel.yaml==0.11.14',
                       'pathspec', 'otherstuf', 'path.py', 'pip',
                       'jujubundlelib', 'virtualenv', 'colander',
                       'jsonschema'],


### PR DESCRIPTION
Description of change
## Checklist
- [X] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
- [X] Are all your commits [logically] grouped and squashed appropriately?
- [X] Does this patch have code coverage?
- [X] Does your code pass `make test`?

I had a newer version of ruamel.yaml installed, when I issued `pip install -e .` I got the pinned version of ruamel.yaml-0.10.23

```
$ sudo pip install -e .
...
Installing collected packages: ruamel.yaml, charm-tools
  Found existing installation: ruamel.yaml 0.11.6
    Uninstalling ruamel.yaml-0.11.6:
      Successfully uninstalled ruamel.yaml-0.11.6
  Running setup.py develop for charm-tools
Successfully installed charm-tools-2.1.2 ruamel.yaml-0.10.23
```
