### PR TITLE
--recursive isn't needed for these templates

### DIFF
--- a/charmtools/templates/reactive_bash/template.py
+++ b/charmtools/templates/reactive_bash/template.py
@@ -69,7 +69,7 @@ class ReactiveBashCharmTemplate(CharmTemplate):
         os.unlink(backupname)
 
     def _clone_template(self, config, output_dir):
-        cmd = "git clone --recursive {} {}".format(
+        cmd = "git clone {} {}".format(
             self._TEMPLATE_URL, output_dir
         )
 

--- a/charmtools/templates/reactive_python/template.py
+++ b/charmtools/templates/reactive_python/template.py
@@ -69,7 +69,7 @@ class ReactivePythonCharmTemplate(CharmTemplate):
         os.unlink(backupname)
 
     def _clone_template(self, config, output_dir):
-        cmd = "git clone --recursive {} {}".format(
+        cmd = "git clone {} {}".format(
             self._TEMPLATE_URL, output_dir
         )
 


### PR DESCRIPTION
There's no need to do --recursive on these templates since there are no submodules present.

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?

