### PR TITLE
proof the actual built charm

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -675,16 +675,19 @@ def main(args=None):
 
         build()
 
-        lint, exit_code = proof.proof(os.getcwd(), False, False)
-        if lint:
-            llog = logging.getLogger("proof")
-            for line in lint:
-                if line[0] == "I":
-                    llog.info(line)
-                elif line[0] == "W":
-                    llog.warn(line)
-                elif line[0] == "E":
-                    llog.error(line)
+        lint, exit_code = proof.proof(build.target_dir, False, False)
+        llog = logging.getLogger("proof")
+
+        if not lint:
+            llog.info('OK!')
+
+        for line in lint:
+            if line[0] == "I":
+                llog.info(line)
+            elif line[0] == "W":
+                llog.warn(line)
+            elif line[0] == "E":
+                llog.error(line)
     except (BuildError, FetchError) as e:
         log.error(*e.args)
         raise SystemExit(1)


### PR DESCRIPTION
This changes the output from this:

```
build: Composing into /home/marco/Projects/silph.co
build: Destination charm directory: /home/marco/Projects/silph.co/trusty/silph-web
build: Please add a `repo` key to your layer.yaml, e.g. repo: git@bitbucket.org:marcoceppi/layer-thesilphroad.git
build: Processing layer: layer:basic
build: Processing layer: layer:nginx
build: Processing layer: layer:apt
build: Processing layer: layer:php-fpm
build: Processing layer: silph-web
build: Processing interface: http
build: Processing interface: php-fpm-stats
build: Processing interface: mysql
build: Processing interface: redis
proof: I: no hooks directory
proof: W: no copyright file
proof: W: README.md includes boilerplate: Step by step instructions on using the charm:
proof: W: README.md includes boilerplate: You can then browse to http://ip-address to configure the service.
proof: W: README.md includes boilerplate: - Upstream mailing list or contact information
proof: W: README.md includes boilerplate: - Feel free to add things if it's useful for users
proof: I: relation website has no hooks
proof: I: relation cache has no hooks
proof: I: relation database has no hooks
proof: I: missing recommended hook install
proof: I: missing recommended hook start
proof: I: missing recommended hook stop
proof: I: missing recommended hook config-changed
proof: I: config.yaml: option ssh-key has no default value
```

Which, as you can see, i sproofing the current (layer) directory. Into:

```
build: Composing into /home/marco/Projects/silph.co
build: Destination charm directory: /home/marco/Projects/silph.co/trusty/silph-web
build: Please add a `repo` key to your layer.yaml, e.g. repo: git@bitbucket.org:marcoceppi/layer-thesilphroad.git
build: Processing layer: layer:basic
build: Processing layer: layer:nginx
build: Processing layer: layer:apt
build: Processing layer: layer:php-fpm
build: Processing layer: silph-web
build: Processing interface: http
build: Processing interface: php-fpm-stats
build: Processing interface: mysql
build: Processing interface: redis
proof: W: README.md includes boilerplate: Step by step instructions on using the charm:
proof: W: README.md includes boilerplate: You can then browse to http://ip-address to configure the service.
proof: W: README.md includes boilerplate: - Upstream mailing list or contact information
proof: W: README.md includes boilerplate: - Feel free to add things if it's useful for users
proof: I: config.yaml: option ssh-key has no default value
```

Which is now proofing the actual layer
