### PR TITLE
Use actual layer name instead of directory name

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -66,7 +66,7 @@ class Fetched(Configable):
             return self._name
         if self.url.startswith(self.NAMESPACE):
             return self.url[len(self.NAMESPACE)+1:]
-        return self.url
+        return self.url.rsplit('/', 1)[-1]
 
     def __repr__(self):
         return "<{} {}:{}>".format(self.__class__.__name__,
@@ -436,7 +436,8 @@ class Builder(object):
                 if phase == "lint":
                     cont &= tactic.lint()
                     if cont is False and self.force is not True:
-                        return
+                        # no message, reason will already have been logged
+                        raise BuildError()
                 elif phase == "read":
                     # We use a read (into memory phase to make layer comps
                     # simpler)
@@ -689,7 +690,8 @@ def main(args=None):
             elif line[0] == "E":
                 llog.error(line)
     except (BuildError, FetchError) as e:
-        log.error(*e.args)
+        if e.args:
+            log.error(*e.args)
         raise SystemExit(1)
 
 

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -76,7 +76,7 @@ class Tactic(object):
 
     @property
     def layer_name(self):
-        return str(self.layer.directory.name)
+        return self.layer.name
 
     @property
     def repo_path(self):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -345,7 +345,8 @@ class TestBuild(unittest.TestCase):
         config = mock.MagicMock(name='config')
 
         base_layer = mock.MagicMock(name='base_layer')
-        base_layer.directory.name = 'base'
+        base_layer.directory.name = 'layer-base'
+        base_layer.name = 'base'
         base = build.tactics.LayerYAML(entity, target, base_layer, config)
         base.data = {
             'defines': {
@@ -364,7 +365,8 @@ class TestBuild(unittest.TestCase):
         self.assertEqual(base.data['options']['base']['foo'], 'FOO')
 
         top_layer = mock.MagicMock(name='top_layer')
-        top_layer.directory.name = 'top'
+        top_layer.directory.name = 'layer-top'
+        top_layer.name = 'top'
         top = build.tactics.LayerYAML(entity, target, top_layer, config)
         top.data = {
             'options': {


### PR DESCRIPTION
Description of change

Use actual layer name instead of directory name (fixes #254)

Also makes it fail fast on tactic lint failures instead of trying to proof the non-existent built charm (fixes #260).

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?