### PR TITLE
use download not install to prevent building locally when building ch…

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -753,7 +753,7 @@ class WheelhouseTactic(ExactMatch, Tactic):
     def _add(self, pip, wheelhouse, *reqs):
         with utils.tempdir(chdir=False) as temp_dir:
             # put in a temp dir first to ensure we track all of the files
-            utils.Process((pip, 'install',
+            utils.Process((pip, 'download',
                            '--no-binary', ':all:',
                            '-d', temp_dir) +
                           reqs).exit_on_error()()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -331,7 +331,7 @@ class TestBuild(unittest.TestCase):
             with mock.patch("path.Path.files"):
                 bu()
                 Process.assert_called_with((
-                    '/tmp/bin/pip3', 'install',
+                    '/tmp/bin/pip3', 'download',
                     '--no-binary', ':all:',
                     '-d', '/tmp',
                     '-r', self.dirname / 'trusty/whlayer/wheelhouse.txt'))


### PR DESCRIPTION
Do not install things when locally running... Found out that some deps were needed to install locally, using download only gets around that.
## Checklist
- [O] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions) -- umm, that address isn't resolvable for me
- [X] Are all your commits [logically] grouped and squashed appropriately?
- [X] Does this patch have code coverage?
- [O] Does your code pass `make test`? -- cant get the tests to pass locally, hopfully travis will run it for me here ;)
