### PR TITLE
Drop unused linting code in the InterfaceCopy tactic

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -272,19 +272,7 @@ class InterfaceCopy(Tactic):
             log.error('Missing implementation for interface role: %s.py',
                       self.role)
             return False
-        valid = True
-        for entry in self.interface.directory.walkfiles():
-            if entry.splitext()[1] != ".py":
-                continue
-            relpath = entry.relpath(self._target.directory)
-            target = self._target.directory / relpath
-            if not target.exists():
-                continue
-            unchanged = utils.delta_python_dump(entry, target,
-                                                from_name=relpath)
-            if not unchanged:
-                valid = False
-        return valid
+        return True
 
 
 class DynamicHookBind(Tactic):


### PR DESCRIPTION
This patch drops some effectively unused logic in the InterfaceCopy.lint method.

AFAIU the goal of the logic being dropped was to calculate a diff between a source and target Python files, however the code seems to have been broken since the very first time it was added (in commit 7a10d7e7db2cd52cd166c92a47faefe4842f1560, the first version of the composer). The reason is that the "entry" and "target" paths that are passed to utils.delta_python_dump will always point to the very same file, so the diff will always be null.

The bug is in the use of the relpath() API:

``` python
>>> import path
>>> entry = path.path("/some/entry")
>>> target_directory = path.path("/the/target")
>>> relpath = entry.relpath(target_directory)
>>> target = target_directory / relpath
>>> entry, target
(path(u'/some/entry'), path(u'/the/target/../../some/entry'))
```

As you can see, "entry" and "target" will point to the same file, as noted above.

Since nobody ever noticed this bug, I think it's safe to assume that the intended behavior is not really very important for the overall functionality of the tool, and since the diffing operation is rather expensive and slows down the program run time, I propose to just drop it.
