### PR TITLE
Fix fetched bzr layer output directory collision

### DIFF
--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -95,11 +95,7 @@ class InterfaceFetcher(fetchers.LocalFetcher):
         """
         u = self.url[len(self.NAMESPACE) + 1:]
         f = get_fetcher(repo)
-        if hasattr(f, "repo"):
-            basename = path(f.repo).name.splitext()[0]
-        else:
-            basename = u
-        return f, path(dir_) / basename
+        return f, path(dir_) / u
 
     def fetch(self, dir_):
         if hasattr(self, "path"):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -405,6 +405,16 @@ class TestBuild(unittest.TestCase):
         })
 
 
+class TestFetchers(unittest.TestCase):
+    @mock.patch.object(build.fetchers, 'get_fetcher')
+    def test_get_repo_fetcher_target(self, get_fetcher):
+        f = get_fetcher()
+        f.repo = '/home/user/deps/foo/trunk'
+        fetcher = build.fetchers.InterfaceFetcher('interface:foo')
+        result = fetcher._get_repo_fetcher_and_target('repo', '/dir_')
+        self.assertEqual(result, (f, '/dir_/foo'))
+
+
 if __name__ == '__main__':
     logging.basicConfig()
     unittest.main()


### PR DESCRIPTION
Fixes #268 which causes any layer using bzr to collide with any other layer using bzr, with the result being that layers can be dropped, or the wrong code used entirely.

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?