### PR TITLE
When includes: is defined, but None set to empty list (fixes #8)

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -535,7 +535,7 @@ class LayerYAML(YAMLTactic):
         # XXX: there will be strange interactions with cs: vs local:
         if 'is' not in data:
             data['is'] = str(self.layer.url)
-        inc = data.get('includes', [])
+        inc = data.get('includes', []) or []
         norm = []
         for i in inc:
             if ":" in i:


### PR DESCRIPTION
When includes: is defined, but None set to empty list (fixes #8)
## Checklist
- [X] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
- [X] Are all your commits [logically] grouped and squashed appropriately?
- [ ] Does this patch have code coverage?
- [X] Does your code pass `make test`?
