### PR TITLE
Use consistent shebang in the same template

### DIFF
--- a/charmtools/templates/bash/files/hooks/relation-name-relation-broken
+++ b/charmtools/templates/bash/files/hooks/relation-name-relation-broken
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/bin/bash
 # This hook runs when the full relation is removed (not just a single member)

--- a/charmtools/templates/bash/files/hooks/relation-name-relation-departed
+++ b/charmtools/templates/bash/files/hooks/relation-name-relation-departed
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This must be renamed to the name of the relation. The goal here is to
 # affect any change needed by the remote unit leaving the relationship.
 # This script should be idempotent.

--- a/charmtools/templates/bash/files/hooks/relation-name-relation-joined
+++ b/charmtools/templates/bash/files/hooks/relation-name-relation-joined
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This must be renamed to the name of the relation. The goal here is to
 # affect any change needed by relationships being formed
 # This script should be idempotent.


### PR DESCRIPTION
Description of change

Shebang was not consistent in the same "bash" template.

[master]
```
$ head -n1 charmtools/templates/bash/files/hooks/*
==> charmtools/templates/bash/files/hooks/config-changed <==
#!/bin/bash

==> charmtools/templates/bash/files/hooks/install <==
#!/bin/bash

==> charmtools/templates/bash/files/hooks/relation-name-relation-broken <==
#!/bin/sh

==> charmtools/templates/bash/files/hooks/relation-name-relation-changed <==
#!/bin/bash

==> charmtools/templates/bash/files/hooks/relation-name-relation-departed <==
#!/bin/sh

==> charmtools/templates/bash/files/hooks/relation-name-relation-joined <==
#!/bin/sh

==> charmtools/templates/bash/files/hooks/start <==
#!/bin/bash

==> charmtools/templates/bash/files/hooks/stop <==
#!/bin/bash

==> charmtools/templates/bash/files/hooks/upgrade-charm <==
#!/bin/bash
```

## Checklist

 - [ ] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions) -> hacking.juju.solutions cannot be resolved.
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage? -> N/A
 - [x] Does your code pass `make test`?

