### PR TITLE
remove argparse from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
         'launchpadlib<1.11',
-        'argparse',
         'cheetah<=2.4.4',
         'pyyaml==3.11',
         'paramiko<2.0.0',


### PR DESCRIPTION
Description of change

## Checklist

 - [ ] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [ ] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [ ] Does your code pass `make test`?

argparse is part of the Python 2.7 stdlib.