### PR TITLE
Ensure JSON output has stable ordering

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -467,7 +467,7 @@ class Builder(object):
         self.manifest.write_text(json.dumps(dict(
             signatures=signatures,
             layers=layers,
-        ), indent=2))
+        ), indent=2, sort_keys=True))
 
     def generate(self):
         layers = self.fetch()


### PR DESCRIPTION
Stable JSON output for Issue #278

## Checklist

 - [ ] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [X] Are all your commits [logically] grouped and squashed appropriately?
 - [] Does this patch have code coverage?
 - [X] Does your code pass `make test`?

Stable ordering is preferred as it makes diffs more readable and makes
it impossible to write flaky tests that rely on implicit ordering.