### PR TITLE
back down requirements for trusty pip (fixes #274)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ nose==1.3.7
 otherstuf==1.1.0
 path.py==8.1.2
 pathspec==0.3.4
-pip>=7.1.2
+pip>=1.5.4
 requests==2.9.1
 responses==0.3.0
 ruamel.yaml==0.10.23

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'pathspec<=0.3.4',
         'otherstuf<=1.1.0',
         'path.py<=8.1.2',
-        'pip>=7.1.2',
+        'pip>=1.5.4',
         'jujubundlelib',
         'virtualenv>=1.11.4',
         'colander<=1.0b1',


### PR DESCRIPTION
This fixes #274 by level-setting pip in setup.py and requirements.txt
