### PR TITLE
Actually activate the venv when building the wheelhouse

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -741,6 +741,7 @@ class WheelhouseTactic(ExactMatch, Tactic):
         super(WheelhouseTactic, self).__init__(*args, **kwargs)
         self.tracked = []
         self.previous = []
+        self._venv = None
 
     def __str__(self):
         directory = self.target.directory / 'wheelhouse'
@@ -750,35 +751,45 @@ class WheelhouseTactic(ExactMatch, Tactic):
         self.previous = existing.previous + [existing]
         return self
 
-    def _add(self, pip, wheelhouse, *reqs):
+    def _add(self, wheelhouse, *reqs):
         with utils.tempdir(chdir=False) as temp_dir:
             # put in a temp dir first to ensure we track all of the files
-            utils.Process((pip, 'install',
-                           '--no-binary', ':all:',
-                           '-d', temp_dir) +
-                          reqs).exit_on_error()()
+            self._pip('download', '--no-binary', ':all:', '-d', temp_dir,
+                      *reqs)
             for wheel in temp_dir.files():
                 dest = wheelhouse / wheel.basename()
                 dest.remove_p()
                 wheel.move(wheelhouse)
                 self.tracked.append(dest)
 
-    def __call__(self, venv=None):
-        create_venv = venv is None
-        venv = venv or path(tempfile.mkdtemp())
-        pip = venv / 'bin' / 'pip3'
+    def _pip(self, *args):
+        assert self._venv is not None
+        # have to use bash to call pip to activate the venv properly first
+        utils.Process(('bash', '-c', ' '.join(
+            ('.', self._venv / 'bin' / 'activate', ';', 'pip3') + args
+        ))).exit_on_error()()
+
+    def __call__(self):
+        create_venv = self._venv is None
+        self._venv = self._venv or path(tempfile.mkdtemp())
         wheelhouse = self.target.directory / 'wheelhouse'
         wheelhouse.mkdir_p()
         if create_venv:
             utils.Process(
-                ('virtualenv', '--python', 'python3', venv)).exit_on_error()()
-            utils.Process(
-                (pip, 'install', '-U', 'pip', 'wheel')).exit_on_error()()
+                ('virtualenv', '--python', 'python3', self._venv)
+            ).exit_on_error()()
+            self._pip('install', '-U',
+                      '"pip>=9.0.0,<10.0.0"',
+                      '"wheel>=0.29.0,<1.0.0"')
+        # we are the top layer; process all lower layers first
         for tactic in self.previous:
-            tactic(venv)
-        self._add(pip, wheelhouse, '-r', self.entity)
+            tactic()
+        # process this layer
+        self._add(wheelhouse, '-r', self.entity)
+        # clean up
         if create_venv:
-            venv.rmtree_p()
+            self._venv.rmtree_p()
+            self._venv = None
 
     def sign(self):
         """return sign in the form {relpath: (origin layer, SHA256)}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -331,10 +331,10 @@ class TestBuild(unittest.TestCase):
             with mock.patch("path.Path.files"):
                 bu()
                 Process.assert_called_with((
-                    '/tmp/bin/pip3', 'install',
-                    '--no-binary', ':all:',
-                    '-d', '/tmp',
-                    '-r', self.dirname / 'trusty/whlayer/wheelhouse.txt'))
+                    'bash', '-c', '. /tmp/bin/activate ;'
+                    ' pip3 download --no-binary :all: '
+                    '-d /tmp -r ' +
+                    self.dirname / 'trusty/whlayer/wheelhouse.txt'))
 
     @mock.patch.object(build.tactics, 'log')
     @mock.patch.object(build.tactics.YAMLTactic, 'read',


### PR DESCRIPTION
Description of change

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?

Fixes #276

Also removes a deprecation warning by switching to `pip download` and
pins the pip version used in the venv to prevent unexpected major
version changes in the future.