### PR TITLE
Make Tactic.trigger signature backwards compatible

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -124,6 +124,9 @@ class TestBuild(unittest.TestCase):
         self.assertTrue((base / "README.md").exists())
         self.assertEqual("dynamic tactics", (base / "README.md").text())
 
+        self.assertTrue((base / "old_tactic").exists())
+        self.assertEqual("processed", (base / "old_tactic").text())
+
         sigs = base / ".build.manifest"
         self.assertTrue(sigs.exists())
         data = json.load(sigs.open())

--- a/tests/trusty/tester/layer.yaml
+++ b/tests/trusty/tester/layer.yaml
@@ -6,6 +6,7 @@ config:
         - vip_cidr
 tactics:
     - layer.custom.READMETactic
+    - layer.custom.OldTactic
 options:
   mysql:
     qux: 'one'

--- a/tests/trusty/tester/layer/custom.py
+++ b/tests/trusty/tester/layer/custom.py
@@ -16,3 +16,19 @@ class READMETactic(Tactic):
         rel = self.entity.relpath(self.layer.directory)
         target = self.target.directory / rel
         target.write_text("dynamic tactics")
+
+
+class OldTactic(Tactic):
+    """Example old-style tactic"""
+    @classmethod
+    def trigger(cls, relpath):
+        return relpath == "old_tactic"
+
+    def __str__(self):
+        return "OldTactic"
+
+    def __call__(self):
+        # Write out a fake readme for testing
+        rel = self.entity.relpath(self.layer.directory)
+        target = self.target.directory / rel
+        target.write_text("processed")

--- a/tests/trusty/tester/old_tactic
+++ b/tests/trusty/tester/old_tactic
@@ -1,0 +1,1 @@
+not processed


### PR DESCRIPTION
Existing custom tactics will break if written to the old signature.

Fixes #295

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
