### PR TITLE
path is deprecated, use Path instead - LP#1660004.

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -11,7 +11,7 @@ import yaml
 
 import charmtools.build.tactics
 
-from path import path
+from path import Path as path
 from collections import OrderedDict
 from charmtools import (utils, repofinder, proof)
 from charmtools.build import inspector

--- a/charmtools/build/config.py
+++ b/charmtools/build/config.py
@@ -3,7 +3,7 @@ from .tactics import load_tactic
 
 from ruamel import yaml
 import logging
-from path import path
+from path import Path as path
 from otherstuf import chainstuf
 
 DEFAULT_IGNORES = [

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -7,7 +7,7 @@ from charmtools.fetchers import (git,  # noqa
                                  get_fetcher,
                                  FetchError)
 
-from path import path
+from path import Path as path
 
 
 class RepoFetcher(fetchers.LocalFetcher):

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from inspect import getargspec
 
-from path import path
+from path import Path as path
 from ruamel import yaml
 from charmtools import utils
 from charmtools.build.errors import BuildError

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from .diff_match_patch import diff_match_patch
 import blessings
 import pathspec
-from path import path
+from path import Path as path
 
 log = logging.getLogger('utils')
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,7 +1,7 @@
 from charmtools import build
 from charmtools.build.errors import BuildError
 from charmtools import utils
-from path import path
+from path import Path as path
 from ruamel import yaml
 import json
 import logging


### PR DESCRIPTION
path.path deprecated since 8.0 of path.py (commit a781071bf0fc9ff477b2d141baec343a7b3ab0e9). Use the correct path.Path.