### PR TITLE
Normalize output directory

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -160,15 +160,13 @@ class Builder(object):
         in <output_dir>/builds/<charmname> when no series is specified or
         <output_dir/<series>/<charmname> when series is specified."""
         if not self._output_dir:
-            self._output_dir = path(os.environ.get('JUJU_REPOSITORY'))
+            self._output_dir = path(os.environ.get('JUJU_REPOSITORY', self.charm)).abspath()
         return self._output_dir
 
     @output_dir.setter
     def output_dir(self, value):
         if value:
             self._output_dir = path(value)
-        else:
-            self._output_dir = path(os.environ.get('JUJU_REPOSITORY'))
 
     @property
     def deps(self):

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -131,6 +131,7 @@ class Builder(object):
         self._name = None
         self._charm = None
         self._top_layer = None
+        self._deps = None
         self.hide_metrics = False
 
     @property
@@ -149,9 +150,19 @@ class Builder(object):
         self._charm = path(value)
 
     @property
+    def deps(self):
+        if not self._deps:
+            self._deps = (path(self.output_dir) / "deps")
+        return self._deps
+
+    @deps.setter
+    def deps(self, value):
+        self._deps = value
+
+    @property
     def charm_metadata(self):
         if not hasattr(self, '_charm_metadata'):
-            md = path(self.charm) / "metadata.yaml"
+            md = self.top_layer / "metadata.yaml"
             try:
                 setattr(
                     self, '_charm_metadata',
@@ -209,9 +220,6 @@ class Builder(object):
         # Generated output will go into this directory
         base = path(self.output_dir)
         self.repo = (base / (self.series if self.series else 'builds'))
-        # And anything it includes from will be placed here
-        # outside the series
-        self.deps = (base / "deps")
         self.target_dir = (self.repo / self.name)
 
     def find_or_create_repo(self, allow_create=True):

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -648,8 +648,15 @@ def main(args=None):
         formatter_class=argparse.RawDescriptionHelpFormatter,)
     parser.add_argument('-l', '--log-level', default=logging.INFO)
     parser.add_argument('-f', '--force', action="store_true")
-    parser.add_argument('-o', '--output-dir', type=path)
-    parser.add_argument('-s', '--series', default=None)
+    parser.add_argument(
+        '-o', '--output-dir', type=path,
+        help='Output directory for build. Defaults to $JUJU_REPOSITORY. The '
+        'resulting charm will be put in <output_dir>/builds/<charmname> or '
+        '<output_dir/<series>/<charmname> when series is specified.')
+    parser.add_argument(
+        '-s', '--series', default=None,
+        help='Build for specific series. Resulting charm will be put in '
+        '<output-dir>/<series>/<name>.')
     parser.add_argument('--hide-metrics', dest="hide_metrics",
                         default=False, action="store_true")
     parser.add_argument('--interface-service',

--- a/tests/multiseries-layer/layer.yaml
+++ b/tests/multiseries-layer/layer.yaml
@@ -1,0 +1,1 @@
+includes: ["trusty/test-base"]

--- a/tests/multiseries-layer/metadata.yaml
+++ b/tests/multiseries-layer/metadata.yaml
@@ -1,0 +1,8 @@
+name: multiseries-layer
+summary: a multiseries layer
+maintainer: Tester <test@er.com>
+description: |
+  multiseries layer
+series:
+  - xenial
+  - trusty

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -220,6 +220,25 @@ class TestBuild(unittest.TestCase):
             init = base / "hooks/relations/mysql/__init__.py"
             self.assertTrue(init.exists())
 
+    def test_multiseries_output_dir(self):
+        os.environ["JUJU_REPOSITORY"] = "out"
+        try:
+            os.mkdir("out")
+        except OSError:
+            pass
+        bu = build.Builder()
+        bu.charm = "multiseries-layer"
+        bu.hide_metrics = True
+        bu.report = False
+        # Simulate commandline call without specified output dir and series
+        bu.output_dir = None
+        bu.series = None
+        bu.normalize_outputdir()
+        bu.check_series()
+        bu()
+        base = path("out") / "builds" / 'multiseries-layer'
+        self.assertTrue(base.exists())
+
     @responses.activate
     def test_remote_interface(self):
         # XXX: this test does pull the git repo in the response

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -221,6 +221,9 @@ class TestBuild(unittest.TestCase):
             self.assertTrue(init.exists())
 
     def test_multiseries_output_dir(self):
+        """ Check if the output dir of a multiseries charm is
+        `$JUJU_REPOSTIORY/builds/...` even when you specify the top level layer
+        by its name instead of by a path to the layer."""
         os.environ["JUJU_REPOSITORY"] = "out"
         try:
             os.mkdir("out")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -239,8 +239,6 @@ class TestBuild(unittest.TestCase):
         # Simulate commandline call without specified output dir and series
         bu.output_dir = None
         bu.series = None
-        bu.normalize_outputdir()
-        bu.check_series()
         bu()
         base = path("out") / "builds" / 'multiseries-layer'
         self.assertTrue(base.exists())

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,15 +1,17 @@
-from charmtools import build
-from charmtools.build.errors import BuildError
-from charmtools import utils
-from path import Path as path
-from ruamel import yaml
+#!/usr/bin/env python2
+import os
 import json
 import logging
+import unittest
+
+from charmtools import build
+from charmtools import utils
+from charmtools.build.errors import BuildError
+from path import Path as path
+from ruamel import yaml
 import mock
-import os
 import pkg_resources
 import responses
-import unittest
 
 
 class TestBuild(unittest.TestCase):
@@ -110,10 +112,10 @@ class TestBuild(unittest.TestCase):
         cyaml = base / "layer.yaml"
         self.assertTrue(cyaml.exists())
         cyaml_data = yaml.load(cyaml.open())
-        self.assertEquals(cyaml_data['includes'], ['trusty/test-base',
-                                                   'trusty/mysql'])
-        self.assertEquals(cyaml_data['is'], 'foo')
-        self.assertEquals(cyaml_data['options']['mysql']['qux'], 'one')
+        self.assertEqual(
+            cyaml_data['includes'], ['trusty/test-base', 'trusty/mysql'])
+        self.assertEqual(cyaml_data['is'], 'foo')
+        self.assertEqual(cyaml_data['options']['mysql']['qux'], 'one')
 
         self.assertTrue((base / "hooks/config-changed").exists())
 
@@ -131,13 +133,13 @@ class TestBuild(unittest.TestCase):
         sigs = base / ".build.manifest"
         self.assertTrue(sigs.exists())
         data = json.load(sigs.open())
-        self.assertEquals(data['signatures']["README.md"], [
+        self.assertEqual(data['signatures']["README.md"], [
             u'foo',
             "static",
             u'cfac20374288c097975e9f25a0d7c81783acdbc81'
             '24302ff4a731a4aea10de99'])
 
-        self.assertEquals(data["signatures"]['metadata.yaml'], [
+        self.assertEqual(data["signatures"]['metadata.yaml'], [
             u'foo',
             "dynamic",
             u'03fc06a5e698e624231b826f4c47a60d3251cbc968fc1183ada444ca09b29ea6'
@@ -194,15 +196,15 @@ class TestBuild(unittest.TestCase):
             # Check that the generated layer.yaml makes sense
             cy = base / "layer.yaml"
             config = yaml.load(cy.open())
-            self.assertEquals(config["includes"], ["trusty/a", "interface:mysql"])
-            self.assertEquals(config["is"], "foo")
+            self.assertEqual(config["includes"], ["trusty/a", "interface:mysql"])
+            self.assertEqual(config["is"], "foo")
 
             # We can even run it more than once
             bu()
             cy = base / "layer.yaml"
             config = yaml.load(cy.open())
-            self.assertEquals(config["includes"], ["trusty/a", "interface:mysql"])
-            self.assertEquals(config["is"], "foo")
+            self.assertEqual(config["includes"], ["trusty/a", "interface:mysql"])
+            self.assertEqual(config["is"], "foo")
 
             # We included an interface, we should be able to assert things about it
             # in its final form as well
@@ -213,8 +215,9 @@ class TestBuild(unittest.TestCase):
 
             # and that we generated the hooks themselves
             for kind in ["joined", "changed", "broken", "departed"]:
-                self.assertTrue((base / "hooks" /
-                                "mysql-relation-{}".format(kind)).exists())
+                self.assertTrue(
+                    (base / "hooks" /
+                     "mysql-relation-{}".format(kind)).exists())
 
             # and ensure we have an init file (the interface doesn't its added)
             init = base / "hooks/relations/mysql/__init__.py"


### PR DESCRIPTION
The `charm build` command's output directory seems to depend on the position of the stars. **This PR normalizes the output directory with a few simple rules and explains the behavior in the help text.**

 1. `output-dir` defaults to `$JUJU_REPOSITORY`.
 2. *If `$JUJU_REPOSITORY` is unset, `output-dir` defaults to the directory of the top-level layer.*
 3.  Build to `<output-dir>/builds/<name>` by default.
 4.  Build to `<output-dir>/<series>/<name>` when series is explicitly defined as argument.
 5. *Do the in-place-upgrade magic when the stars are right*

This fixes a couple of issues:

- Charm build output dir is different depending on where you run it: https://github.com/juju/charm-tools/issues/305
- Output directory is a lie: https://github.com/juju/charm-tools/issues/213
- Charm build outputs to trusty if top-level layer doesn't include series: https://github.com/juju/charm-tools/issues/259

PS: *I'd also like to remove 2. and 5. but this might give some issue with backwards compatibility. In my opinion, if $JUJU_REPOSITORY isn't set, and no output-dir is specified, charm build should display an error message explaining this. This will greatly help new users who haven't set $JUJU_REPOSITORY. @johnsca , @marcoceppi : Thoughts?*




## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
