### PR TITLE
Use safe version of yaml.load

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -155,7 +155,7 @@ class Builder(object):
             try:
                 setattr(
                     self, '_charm_metadata',
-                    yaml.load(md.open()) if md.exists() else None)
+                    yaml.safe_load(md.open()) if md.exists() else None)
             except yaml.YAMLError as e:
                 log.debug(e)
                 raise BuildError("Failed to process {0}. "

--- a/charmtools/build/config.py
+++ b/charmtools/build/config.py
@@ -51,7 +51,7 @@ class BuildConfig(chainstuf):
             raise OSError("Missing Config File {}".format(config_file))
         try:
             if config_file.exists() and config_file.text().strip() != "":
-                data = yaml.load(config_file.open())
+                data = yaml.safe_load(config_file.open())
                 self.configured = True
         except yaml.parser.ParserError:
             logging.critical("Malformed Config file: {}".format(config_file))

--- a/charmtools/build/inspector.py
+++ b/charmtools/build/inspector.py
@@ -44,7 +44,7 @@ def inspect(charm, force_styling=False):
     if not manp.exists() or not comp.exists():
         return
     manifest = json.loads(manp.text())
-    composer = yaml.load(comp.open())
+    composer = yaml.safe_load(comp.open())
     a, c, d = utils.delta_signatures(manp)
 
     # ordered list of layers used for legend


### PR DESCRIPTION
`charm build` on Ubuntu 17.04 throws a nasty warning because we use `yaml.load` instead of `yaml.safe_load`. This PR fixes that issue.

Output with warning:

```
build: Composing into /home/merlijn/PHD/tengu/tengu-charms/charms
build: Destination charm directory: /home/merlijn/PHD/tengu/tengu-charms/charms/builds/ssl-termination-proxy
py.warnings: /usr/lib/python2.7/dist-packages/charmtools/build/config.py:54: UnsafeLoaderWarning: 
The default 'Loader' for 'load(stream)' without further arguments can be unsafe.
Use 'load(stream, Loader=ruamel.yaml.Loader)' explicitly if that is OK.
Alternatively include the following in your code:

  import warnings
  warnings.simplefilter('ignore', ruamel.yaml.error.UnsafeLoaderWarning)

In most other cases you should consider using 'safe_load(stream)'
  data = yaml.load(config_file.open())

build: Processing layer: layer:basic
build: Processing layer: layer:apt
build: Processing layer: layer:nginx
build: Processing layer: layer:lets-encrypt (from lets-encrypt)
build: Processing layer: ssl-termination-proxy (from ssl-termination-proxy)
build: Processing interface: http
```


## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
