### PR TITLE
Add option for wheelhouse overrides

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -332,7 +332,7 @@ class Builder(object):
         if self.wheelhouse_overrides:
             existing_tactic = output_files.get('wheelhouse.txt')
             output_files['wheelhouse.txt'] = WheelhouseTactic(
-                self.wheelhouse_overrides,
+                str(self.wheelhouse_overrides),
                 self.target,
                 layers["layers"][-1],
                 next_config,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -328,17 +328,23 @@ class TestBuild(unittest.TestCase):
         bu.charm = "trusty/whlayer"
         bu.hide_metrics = True
         bu.report = False
+        bu.wheelhouse_overrides = self.dirname / 'wh-over.txt'
 
         # remove the sign phase
         bu.PHASES = bu.PHASES[:-2]
         with mock.patch("path.Path.mkdir_p"):
             with mock.patch("path.Path.files"):
                 bu()
-                Process.assert_called_with((
+                Process.assert_any_call((
                     'bash', '-c', '. /tmp/bin/activate ;'
                     ' pip3 download --no-binary :all: '
                     '-d /tmp -r ' +
                     self.dirname / 'trusty/whlayer/wheelhouse.txt'))
+                Process.assert_any_call((
+                    'bash', '-c', '. /tmp/bin/activate ;'
+                    ' pip3 download --no-binary :all: '
+                    '-d /tmp -r ' +
+                    self.dirname / 'wh-over.txt'))
 
     @mock.patch.object(build.tactics, 'log')
     @mock.patch.object(build.tactics.YAMLTactic, 'read',


### PR DESCRIPTION
To facilitate CI and testing of charms with new versions of Python dependencies, particularly those from base layers, you can now provide a wheelhouse.txt file via the `charm-build` CLI that will be applied
after all others which can thus override any dependencies from lower layers.