### PR TITLE
Request snap info instead of charm version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,7 +21,7 @@ Otherwise, if you have a feature request or issue with any other charm command p
 
 ## What version am I running?
 
-I ran the following command: `charm version` and got the following ouput:
+I ran the following command: `snap info charm` and got the following ouput:
 
 ```
 PUT YOUR OUTPUT HERE


### PR DESCRIPTION
Since we now only recommend using the snap, and the snap revision is more consistently updated, it is better to have that on issues than the output of `charm version`.