### PR TITLE
Validate that input and output paths can be accessed by snap

### DIFF
--- a/charmtools/create.py
+++ b/charmtools/create.py
@@ -96,6 +96,7 @@ def main():
     generator = CharmGenerator(args)
     try:
         generator.create_charm()
+        return 0
     except CharmGeneratorException as e:
         log.error(e)
         return 1

--- a/charmtools/generators/generator.py
+++ b/charmtools/generators/generator.py
@@ -57,7 +57,13 @@ class CharmGenerator(object):
         create the files and directories for the new charm.
 
         """
+        home_path = os.path.expanduser('~')
         output_path = self._get_output_path()
+        if home_path == '~':  # expansion failed
+            raise CharmGeneratorException('Could not determine home directory')
+        if not os.path.abspath(output_path).startswith(home_path):
+            raise CharmGeneratorException('Charms can only be created under '
+                                          'your home directory.')
         if os.path.exists(output_path):
             raise CharmGeneratorException(
                 '{} exists. Please move it out of the way.'.format(
@@ -124,4 +130,7 @@ class CharmGenerator(object):
         return tempfile.mkdtemp()
 
     def _cleanup(self, tempdir):
-        shutil.rmtree(tempdir)
+        if os.path.exists(tempdir):
+            # not sure how it could actually get to this point without the
+            # tempdir existing, but we had some reports, so we should check
+            shutil.rmtree(tempdir)


### PR DESCRIPTION
Fixes #342 and partially addresses #327 by rejecting attempts to build or create into or from directories outside of `$HOME` with a clear error message.

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
