### PR TITLE
Fix home dir check in confined snap

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -550,8 +550,9 @@ class Builder(object):
         self.output_dir = od
 
     def _check_path(self, path_to_check):
-        home_dir = os.path.expanduser('~')
-        if home_dir == '~':
+        # have to expand ~user instead of ~ because $HOME is set to snap dir
+        home_dir = os.path.expanduser('~{}'.format(os.environ['USER']))
+        if home_dir.startswith('~'):  # expansion failed
             raise BuildError('Could not determine home directory')
         return os.path.abspath(path_to_check).startswith(home_dir)
 

--- a/charmtools/generators/generator.py
+++ b/charmtools/generators/generator.py
@@ -57,9 +57,10 @@ class CharmGenerator(object):
         create the files and directories for the new charm.
 
         """
-        home_path = os.path.expanduser('~')
+        # have to expand ~user instead of ~ because $HOME is set to snap dir
+        home_path = os.path.expanduser('~{}'.format(os.environ['USER']))
         output_path = self._get_output_path()
-        if home_path == '~':  # expansion failed
+        if home_path.startswith('~'):  # expansion failed
             raise CharmGeneratorException('Could not determine home directory')
         if not os.path.abspath(output_path).startswith(home_path):
             raise CharmGeneratorException('Charms can only be created under '

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -16,6 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import shutil
 import tempfile
 from mock import patch, Mock
 from unittest import TestCase
@@ -39,12 +40,18 @@ class CharmGeneratorTest(TestCase):
 
         self.c = CharmGenerator(opts)
 
+    def tearDown(self):
+        shutil.rmtree(self.c.opts.charmhome, ignore_errors=True)
+
     def test_load_plugin(self):
         plugin = self.c._load_plugin()
 
         self.assertIsInstance(plugin, BashCharmTemplate)
 
-    def test_create_charm_output_path_exists(self):
+    @patch.dict(os.environ, {'USER': 'test'})
+    @patch('os.path.expanduser')
+    def test_create_charm_output_path_exists(self, eu):
+        eu.return_value = self.c.opts.charmhome
         os.mkdir(self.c._get_output_path())
         with self.assertRaises(CharmGeneratorException) as e:
             self.c.create_charm()

--- a/tests/test_charm_create.py
+++ b/tests/test_charm_create.py
@@ -57,13 +57,15 @@ class BashCreateTest(TestCase):
 
         setup_parser.return_value.parse_args.return_value = args
 
-        self.assertEqual(main(), 1)
+        with patch.dict('os.environ', {'USER': 'test'}):
+            self.assertEqual(main(), 1)
         assert mlog.error.called
         self.assertIn('home directory', str(mlog.error.call_args[0]))
 
-        with patch('os.path.expanduser') as eu:
-            eu.return_value = self.tempdir
-            self.assertEqual(main(), 0)
+        with patch.dict('os.environ', {'USER': 'test'}):
+            with patch('os.path.expanduser') as eu:
+                eu.return_value = self.tempdir
+                self.assertEqual(main(), 0)
 
         outputdir = join(self.tempdir, args.charmname)
         actual_files = list(flatten(outputdir))
@@ -84,7 +86,8 @@ class BashCreateTest(TestCase):
 
         setup_parser.return_value.parse_args.return_value = args
 
-        with patch.dict('os.environ', {'CHARM_HOME': self.tempdir}):
+        with patch.dict('os.environ', {'CHARM_HOME': self.tempdir,
+                                       'USER': 'test'}):
             with patch('os.path.expanduser') as eu:
                 eu.return_value = self.tempdir
                 self.assertEqual(main(), 0)
@@ -109,7 +112,10 @@ class BashCreateTest(TestCase):
         setup_parser.return_value.parse_args.return_value = args
         os.mkdir(join(self.tempdir, args.charmname))
 
-        self.assertEqual(1, main())
+        with patch.dict('os.environ', {'USER': 'test'}):
+            with patch('os.path.expanduser') as eu:
+                eu.return_value = self.tempdir
+                self.assertEqual(1, main())
 
 
 class ParserTest(TestCase):


### PR DESCRIPTION
In the strictly confined snap, $HOME is set to the snap dir instead of the user's home dir.  Expanding ~user gets the correct path.

Fixes #348

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
