### PR TITLE
Fix creation of config file

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -447,6 +447,7 @@ class Builder(object):
             conf = yaml.safe_load(conf_file.text())
             cid = conf['cid']
         else:
+            conf_file.parent.makedirs_p()
             cid = str(uuid.uuid4())
             conf_file.write_text(yaml.dump({'cid': cid}))
         try:


### PR DESCRIPTION
Config dir doesn't exist by default in the snap.

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
