### PR TITLE
Don't rely on any env vars to determine $HOME

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -575,9 +575,8 @@ class Builder(object):
         self.output_dir = od
 
     def _check_path(self, path_to_check):
-        # have to expand ~user instead of ~ because $HOME is set to snap dir
-        home_dir = os.path.expanduser('~{}'.format(os.environ['USER']))
-        if home_dir.startswith('~'):  # expansion failed
+        home_dir = utils.get_home()
+        if not home_dir:  # expansion failed
             raise BuildError('Could not determine home directory')
         return os.path.abspath(path_to_check).startswith(home_dir)
 

--- a/charmtools/generators/generator.py
+++ b/charmtools/generators/generator.py
@@ -23,6 +23,7 @@ import tempfile
 import pkg_resources
 
 from .utils import apt_fill
+from charmtools.utils import get_home
 
 try:
     from ubuntutools.config import ubu_email as get_maintainer
@@ -57,10 +58,9 @@ class CharmGenerator(object):
         create the files and directories for the new charm.
 
         """
-        # have to expand ~user instead of ~ because $HOME is set to snap dir
-        home_path = os.path.expanduser('~{}'.format(os.environ['USER']))
+        home_path = get_home()
         output_path = self._get_output_path()
-        if home_path.startswith('~'):  # expansion failed
+        if not home_path:  # expansion failed
             raise CharmGeneratorException('Could not determine home directory')
         if not os.path.abspath(output_path).startswith(home_path):
             raise CharmGeneratorException('Charms can only be created under '

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import pwd
 from contextlib import contextmanager
 
 from .diff_match_patch import diff_match_patch
@@ -593,3 +594,17 @@ class OrderedSet(collections.MutableSet):
         if isinstance(other, OrderedSet):
             return len(self) == len(other) and list(self) == list(other)
         return set(self) == set(other)
+
+
+def get_home():
+    """
+    Get the current user's home directory in a portable way
+    that doesn't depend on env vars.
+
+    If the home directory can't be determined, it will return None.
+    """
+    username = pwd.getpwuid(os.getuid()).pw_name
+    home = os.path.expanduser('~{}'.format(username))
+    if home.startswith('~'):
+        return None
+    return home

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import os
+import mock
 from unittest import TestCase
 from charmtools import utils
 from StringIO import StringIO
@@ -41,3 +43,9 @@ class TestUtils(TestCase):
         self.assertIn("Beta", output)
         self.assertIn("@when('db.ready'", output)
         self.assertIn("bar", output)
+
+    def test_get_home(self):
+        # expanduser('~') works in test env, but not in snap
+        assert utils.get_home() == os.path.expanduser('~')
+        with mock.patch('os.path.expanduser', lambda u: u):
+            assert utils.get_home() is None


### PR DESCRIPTION
Some build environments (i.e., Jenkins) don't set `$USER`, and in the snap, `$HOME` is set to something other than the user's home directory.  So we need to get the correct path in a way that doesn't rely on those env vars.

Fixes #367

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
