### PR TITLE
Reintroduce the juju-test command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,3 +53,4 @@ The most commonly used commands are the charm life-cycle commands::
     charm push      # push a charm to the store
     charm release   # release a pushed charm to the public
     charm show      # show information about a charm in the store
+    charm test      # perform unit tests on a charm ala 'juju test'

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
             'charm-help = charmtools.cli:usage',
             'charm-layers = charmtools.build.builder:inspect',
             'charm-proof = charmtools.proof:main',
+            'charm-test = charmtools.test:main',
+            'juju-test = charmtools.test:main',
             'charm-pull-source = charmtools.pullsource:main',
             'charm-version = charmtools.version:main',
         ],

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,13 @@ apps:
       - browser-support
       - home
       - removable-media
+  juju-test:
+    command: env PATH=$SNAP/bin:$SNAP/usr/bin:$SNAP/libexec/git-core:$PATH GIT_TEMPLATE_DIR=$SNAP/share/git-core/templates UNIXCONFDIR=$SNAP/etc PREFIX=$SNAP GIT_EXEC_PATH=$SNAP/usr/lib/git-core LC_ALL=C.UTF-8 $SNAP/bin/charm-test
+    plugs:
+      - network
+      - browser-support
+      - home
+      - removable-media
 parts:
   charm:
     source: https://github.com/juju/charmstore-client.git

--- a/tests/test_charm_test.py
+++ b/tests/test_charm_test.py
@@ -1,11 +1,11 @@
-"""Unit test for juju_test"""
+"""Unit test for charm_test"""
 
 import os
 import unittest
 import yaml
 
 from contextlib import contextmanager
-from charmtools import test as juju_test
+from charmtools import test as charm_test
 from mock import patch, call, Mock, MagicMock
 
 RAW_ENVIRONMENTS_YAML = '''
@@ -63,7 +63,7 @@ class JujuTestPluginTest(unittest.TestCase):
     @patch('subprocess.check_output')
     def test_get_gojuju_version(self, mock_check_output):
         mock_check_output.side_effect = ['1.2.3-series-xxx']
-        version = juju_test.get_juju_version()
+        version = charm_test.get_juju_version()
 
         self.assertEqual(version.major, 1)
         self.assertEqual(version.minor, 2)
@@ -74,7 +74,7 @@ class JujuTestPluginTest(unittest.TestCase):
     @patch('subprocess.check_output')
     def test_get_pyjuju_version(self, mcheck_output):
         mcheck_output.side_effect = [Exception('Non-zero exit'), 'juju 8.6']
-        version = juju_test.get_juju_version()
+        version = charm_test.get_juju_version()
 
         self.assertEqual(version.major, 8)
         self.assertEqual(version.minor, 6)
@@ -85,7 +85,7 @@ class JujuTestPluginTest(unittest.TestCase):
     @patch('subprocess.check_output')
     def test_get_juju_version_malformed(self, mcheck_output):
         mcheck_output.return_value = '1.2.3.45'
-        version = juju_test.get_juju_version()
+        version = charm_test.get_juju_version()
 
         self.assertEqual(version.major, 1)
         self.assertEqual(version.minor, 2)
@@ -94,17 +94,17 @@ class JujuTestPluginTest(unittest.TestCase):
         mcheck_output.assert_called_once_with(['juju', 'version'])
 
     def test_convert_to_timedelta(self):
-        self.assertEqual(300, juju_test.convert_to_timedelta('5m'))
-        self.assertEqual(300, juju_test.convert_to_timedelta('300'))
-        self.assertEqual(100, juju_test.convert_to_timedelta('100s'))
-        self.assertEqual(100, juju_test.convert_to_timedelta(100))
-        self.assertEqual(60, juju_test.convert_to_timedelta('1m'))
-        self.assertEqual(60 * 60, juju_test.convert_to_timedelta('1h'))
+        self.assertEqual(300, charm_test.convert_to_timedelta('5m'))
+        self.assertEqual(300, charm_test.convert_to_timedelta('300'))
+        self.assertEqual(100, charm_test.convert_to_timedelta('100s'))
+        self.assertEqual(100, charm_test.convert_to_timedelta(100))
+        self.assertEqual(60, charm_test.convert_to_timedelta('1m'))
+        self.assertEqual(60 * 60, charm_test.convert_to_timedelta('1h'))
 
     def test_conductor_find_tests(self):
         with cd('tests_functional/charms/test/'):
             args = Arguments(tests="dummy")
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             results = c.find_tests()
             self.assertIn('00_setup', results)
             self.assertNotIn('helpers.bash', results)
@@ -112,14 +112,14 @@ class JujuTestPluginTest(unittest.TestCase):
     def test_conductor_find_tests_fails(self):
         with cd('tests_functional/charms/mod-spdy/'):
             args = Arguments(tests="dummy")
-            self.assertRaises(juju_test.NoTests, juju_test.Conductor, args)
+            self.assertRaises(charm_test.NoTests, charm_test.Conductor, args)
 
     def test_conductor_ignores_arbitrary_env(self):
         """Ensure that the conductor ignores other env vars."""
         os.environ['CHARMTOOLS_TEST'] = 'FOOBAR'
         args = Arguments(tests="dummy")
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             self.assertNotIn('CHARMTOOLS_TEST', c.env)
 
     def test_conductor_keeps_whitelist_env(self):
@@ -129,7 +129,7 @@ class JujuTestPluginTest(unittest.TestCase):
         os.environ['SSH_AUTH_SOCK'] = 'FOOBAR'
         args = Arguments(tests="dummy")
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             self.assertEqual('FOOBAR', c.env['PATH'])
             self.assertEqual('FOOBAR', c.env['SSH_AGENT_PID'])
             self.assertEqual('FOOBAR', c.env['SSH_AUTH_SOCK'])
@@ -141,15 +141,15 @@ class JujuTestPluginTest(unittest.TestCase):
             os.environ['BAR'] = 'BAZ'
             args = Arguments(tests="dummy")
             args.preserve_environment_variables = "FOO,BAR"
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             self.assertEqual('BAR', c.env['FOO'])
             self.assertEqual('BAZ', c.env['BAR'])
 
-    @patch.object(juju_test.Conductor, 'find_tests')
+    @patch.object(charm_test.Conductor, 'find_tests')
     def test_conductor_find_tests_exception(self, mfind_tests):
         mfind_tests.return_value = None
         args = Arguments(tests=None)
-        self.assertRaises(juju_test.NoTests, juju_test.Conductor, args)
+        self.assertRaises(charm_test.NoTests, charm_test.Conductor, args)
 
     @patch('subprocess.check_output')
     def test_conductor_status(self, mcheck_output):
@@ -167,7 +167,7 @@ class JujuTestPluginTest(unittest.TestCase):
         juju_env = 'test'
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             results = c.status(juju_env)
 
             mcheck_output.assert_called_with(
@@ -188,7 +188,7 @@ class JujuTestPluginTest(unittest.TestCase):
 
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             results = c.load_environments_yaml()
             mock_open.assert_called_once_with(
                 os.path.join(
@@ -201,42 +201,42 @@ class JujuTestPluginTest(unittest.TestCase):
         mock_exists.return_value = False
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             self.assertRaises(IOError, c.load_environments_yaml)
 
-    @patch.object(juju_test.Conductor, 'load_environments_yaml')
+    @patch.object(charm_test.Conductor, 'load_environments_yaml')
     def test_get_environment(self, mock_conductor_ley):
         mock_conductor_ley.return_value = yaml.safe_load(RAW_ENVIRONMENTS_YAML)
 
         juju_env = 'gojuju'
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             environment = c.get_environment(juju_env)
 
             self.assertEqual(
                 environment,
                 PARSED_ENVIRONMENTS_YAML['environments'][juju_env])
 
-    @patch.object(juju_test.Conductor, 'load_environments_yaml')
+    @patch.object(charm_test.Conductor, 'load_environments_yaml')
     def test_get_environment_fails(self, mock_conductor_ley):
         mock_conductor_ley.side_effect = IOError
 
         juju_env = 'gojuju'
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
 
             self.assertRaises(IOError, c.get_environment, juju_env)
 
-    @patch.object(juju_test.Conductor, 'load_environments_yaml')
+    @patch.object(charm_test.Conductor, 'load_environments_yaml')
     def test_get_environment_notfound(self, mock_conductor_ley):
         mock_conductor_ley.return_value = yaml.safe_load(RAW_ENVIRONMENTS_YAML)
 
         juju_env = 'dont-exist'
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
 
             self.assertRaises(KeyError, c.get_environment, juju_env)
 
@@ -244,8 +244,8 @@ class JujuTestPluginTest(unittest.TestCase):
     def test_conductor_destroy(self, mock_check_call):
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=1, patch=1)
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=1, patch=1)
             good_env = 'valid'
             c.destroy(good_env)
 
@@ -255,14 +255,14 @@ class JujuTestPluginTest(unittest.TestCase):
             )
 
             mock_check_call.reset_mock()
-            c.juju_version = juju_test.JujuVersion(major=1, minor=17, patch=0)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=17, patch=0)
             c.destroy(good_env)
 
             mock_check_call.assert_called_once_with(
                 ['juju', 'destroy-environment', '-y', good_env], env=c.env)
 
             mock_check_call.reset_mock()
-            c.juju_version = juju_test.JujuVersion(major=0, minor=8, patch=0)
+            c.juju_version = charm_test.JujuVersion(major=0, minor=8, patch=0)
             c.destroy(good_env)
 
             expected_cmd = 'echo y | juju destroy-environment -e %s' % good_env
@@ -278,17 +278,17 @@ class JujuTestPluginTest(unittest.TestCase):
 
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=8, patch=0)
-            self.assertRaises(juju_test.DestroyUnreliable, c.destroy, bad_env)
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=8, patch=0)
+            self.assertRaises(charm_test.DestroyUnreliable, c.destroy, bad_env)
 
             mock_check_call.reset_mock()
-            c.juju_version = juju_test.JujuVersion(major=0, minor=8, patch=0)
-            self.assertRaises(juju_test.DestroyUnreliable, c.destroy, bad_env)
+            c.juju_version = charm_test.JujuVersion(major=0, minor=8, patch=0)
+            self.assertRaises(charm_test.DestroyUnreliable, c.destroy, bad_env)
 
     @patch('time.sleep')
     @patch('subprocess.check_call')
-    @patch.object(juju_test.Conductor, 'status')
+    @patch.object(charm_test.Conductor, 'status')
     def test_conductor_bootstrap(self, mock_status, mcheck_output, msleep):
         goyml_output = '''
         machines:
@@ -319,8 +319,8 @@ class JujuTestPluginTest(unittest.TestCase):
 
         args = Arguments(tests='dummy', upload_tools=False, constraints=False)
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=8, patch=0)
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=8, patch=0)
 
             c.bootstrap(juju_env)
             mcheck_output.assert_called_once_with(expected_cmd, env=c.env)
@@ -333,15 +333,15 @@ class JujuTestPluginTest(unittest.TestCase):
             args = Arguments(
                 tests='dummy', upload_tools=False,
                 constraints=False)
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=0, minor=8, patch=0)
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=0, minor=8, patch=0)
 
             c.bootstrap(juju_env)
             mcheck_output.assert_called_once_with(expected_cmd, env=c.env)
 
     @patch('time.sleep')
     @patch('subprocess.check_call')
-    @patch.object(juju_test.Conductor, 'status')
+    @patch.object(charm_test.Conductor, 'status')
     def test_conductor_bootstrap_go_opts(self, mstatus, mcheck_output, msleep):
         goyml_output = '''
         machines:
@@ -360,8 +360,8 @@ class JujuTestPluginTest(unittest.TestCase):
 
         args = Arguments(tests='dummy', upload_tools=True, constraints=False)
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=8, patch=0)
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=8, patch=0)
 
             c.bootstrap(juju_env)
             mcheck_output.assert_called_once_with(expected_cmd, env=c.env)
@@ -373,8 +373,8 @@ class JujuTestPluginTest(unittest.TestCase):
 
             args = Arguments(tests='dummy', upload_tools=False,
                              constraints='mem=8G,arch=arm')
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=8, patch=0)
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=8, patch=0)
 
             c.bootstrap(juju_env)
             mcheck_output.assert_called_once_with(const_cmd, env=c.env)
@@ -387,14 +387,14 @@ class JujuTestPluginTest(unittest.TestCase):
         juju_env = 'bad-env'
         args = Arguments(tests='dummy', upload_tools=True, constraints=False)
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=8, patch=0)
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=8, patch=0)
 
-            self.assertRaises(juju_test.BootstrapError, c.bootstrap, juju_env)
+            self.assertRaises(charm_test.BootstrapError, c.bootstrap, juju_env)
 
     @patch('subprocess.check_call')
-    @patch.object(juju_test, 'timeout')
-    @patch.object(juju_test.Conductor, 'status')
+    @patch.object(charm_test, 'timeout')
+    @patch.object(charm_test.Conductor, 'status')
     def test_conductor_bootstrap_unreliable(self, mock_status, mtimeout,
                                             mcheck_output):
         goyml_output = '''
@@ -408,30 +408,30 @@ class JujuTestPluginTest(unittest.TestCase):
         services: {}'''
 
         gostatus_output = yaml.safe_load(goyml_output)
-        mtimeout.side_effect = juju_test.TimeoutError
+        mtimeout.side_effect = charm_test.TimeoutError
         mock_status.return_value = gostatus_output
         jenv = 'test-env'
 
         args = Arguments(tests='dummy', upload_tools=False, constraints=False)
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=8, patch=0)
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=8, patch=0)
 
             self.assertRaises(
-                juju_test.BootstrapUnreliable, c.bootstrap, jenv, 1)
+                charm_test.BootstrapUnreliable, c.bootstrap, jenv, 1)
 
     def test_conductor_isolate_environment(self):
         args = Arguments(tests='dummy')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
+            c = charm_test.Conductor(args)
             self.assertRaises(
                 NotImplementedError, c.isolate_environment, 'dummy')
 
     def test_orchestra_map_status_code(self):
         with cd('tests_functional/charms/test/'):
             args = Arguments(tests='dummy')
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             self.assertEqual('pass', o.map_status_code(0))
             self.assertEqual('fail', o.map_status_code(1))
@@ -441,8 +441,8 @@ class JujuTestPluginTest(unittest.TestCase):
     def test_orchestra_determine_status_pass(self):
         with cd('tests_functional/charms/test/'):
             args = Arguments(tests='dummy', on_timeout='pass')
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             self.assertEqual('fail', o.determine_status(1))
             self.assertEqual('skip', o.determine_status(100))
@@ -452,8 +452,8 @@ class JujuTestPluginTest(unittest.TestCase):
     def test_orchestra_determine_status_skip(self):
         with cd('tests_functional/charms/test/'):
             args = Arguments(tests='dummy', on_timeout='skip')
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             self.assertEqual('pass', o.determine_status(0))
             self.assertEqual('fail', o.determine_status(1))
@@ -465,8 +465,8 @@ class JujuTestPluginTest(unittest.TestCase):
             args = Arguments(
                 tests='dummy', on_timeout='fail',
                 fail_on_skip=True)
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             self.assertEqual('pass', o.determine_status(0))
             self.assertEqual('fail', o.determine_status(1))
@@ -481,68 +481,68 @@ class JujuTestPluginTest(unittest.TestCase):
     def test_orchestra_print_status_pass(self):
         with cd('tests_functional/charms/test/'):
             args = Arguments(tests='dummy', on_timeout='pass')
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
             o.log.status = MagicMock()
 
             o.print_status(0)
-            o.log.status.assert_called_once_with('%s' % juju_test.TEST_PASS)
+            o.log.status.assert_called_once_with('%s' % charm_test.TEST_PASS)
 
             o.log.status.reset_mock()
             o.print_status(124)
             o.log.status.assert_called_with(
-                '%s (%s)' % (juju_test.TEST_PASS, juju_test.TEST_TIMEOUT))
+                '%s (%s)' % (charm_test.TEST_PASS, charm_test.TEST_TIMEOUT))
 
     def test_orchestra_print_status_skip(self):
         with cd('tests_functional/charms/test/'):
             args = Arguments(tests='dummy', on_timeout='skip')
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
             o.log.status = MagicMock()
 
             o.print_status(100)
-            o.log.status.assert_called_once_with('%s' % juju_test.TEST_SKIP)
+            o.log.status.assert_called_once_with('%s' % charm_test.TEST_SKIP)
 
             o.log.status.reset_mock()
             o.print_status(124)
             o.log.status.assert_called_with(
-                '%s (%s)' % (juju_test.TEST_SKIP, juju_test.TEST_TIMEOUT))
+                '%s (%s)' % (charm_test.TEST_SKIP, charm_test.TEST_TIMEOUT))
 
     def test_orchestra_print_status_fail(self):
         with cd('tests_functional/charms/test/'):
             args = Arguments(
                 tests='dummy', on_timeout='fail',
                 fail_on_skip=True)
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
             o.log.status = MagicMock()
 
             o.print_status(1)
-            o.log.status.assert_called_once_with('%s' % juju_test.TEST_FAIL)
+            o.log.status.assert_called_once_with('%s' % charm_test.TEST_FAIL)
 
             o.log.status.reset_mock()
             o.print_status(100)
-            o.log.status.assert_called_with('%s (%s)' % (juju_test.TEST_FAIL,
-                                                         juju_test.TEST_SKIP))
+            o.log.status.assert_called_with('%s (%s)' % (charm_test.TEST_FAIL,
+                                                         charm_test.TEST_SKIP))
 
             o.log.status.reset_mock()
             o.print_status(124)
             o.log.status.assert_called_with(
-                '%s (%s)' % (juju_test.TEST_FAIL, juju_test.TEST_TIMEOUT))
+                '%s (%s)' % (charm_test.TEST_FAIL, charm_test.TEST_TIMEOUT))
 
             o.conductor.args.on_timeout = 'skip'
             o.log.status.reset_mock()
             o.print_status(124)
             o.log.status.assert_called_with(
-                '%s (%s)' % (juju_test.TEST_FAIL, juju_test.TEST_TIMEOUT))
+                '%s (%s)' % (charm_test.TEST_FAIL, charm_test.TEST_TIMEOUT))
 
     def test_orchestra_is_passing_code(self):
         with cd('tests_functional/charms/test/'):
             args = Arguments(
                 tests='dummy', on_timeout='pass',
                 fail_on_skip=False)
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             self.assertTrue(o.is_passing_code(0))
             self.assertTrue(o.is_passing_code(100))
@@ -564,8 +564,8 @@ class JujuTestPluginTest(unittest.TestCase):
         with cd('tests_functional/charms/test/'):
             juju_env = 'test'
             args = Arguments(tests='dummy', juju_env=juju_env)
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
             expected_env = c.env
             expected_env['JUJU_ENV'] = juju_env
 
@@ -580,9 +580,9 @@ class JujuTestPluginTest(unittest.TestCase):
         logdir = '/tmp/'
         args = Arguments(tests='dummy', juju_env=juju_env)
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=0, minor=8, patch=2)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=0, minor=8, patch=2)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             expected_cmd = ['rsync', '-a', '-v', '-z', '-R', '-e',
                             'juju ssh -e %s' % juju_env,
@@ -593,7 +593,7 @@ class JujuTestPluginTest(unittest.TestCase):
             mcheck_call.assert_called_once_with(expected_cmd, env=o.env)
 
     @patch('subprocess.check_call')
-    @patch.object(juju_test.Conductor, 'status')
+    @patch.object(charm_test.Conductor, 'status')
     def test_orchestra_rsync_go(self, mstatus, mcheck_call):
         goyml_output = '''
         machines:
@@ -630,9 +630,9 @@ class JujuTestPluginTest(unittest.TestCase):
         logdir = '/tmp/'
         args = Arguments(tests='dummy', juju_env=juju_env)
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=10, patch=0)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=10, patch=0)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             expected_cmd = ['rsync', '-a', '-v', '-z', '-R', '-e', 'ssh',
                             'ubuntu@%s:%s' % (dns_name, path), logdir]
@@ -641,8 +641,8 @@ class JujuTestPluginTest(unittest.TestCase):
 
             mcheck_call.assert_called_once_with(expected_cmd, env=o.env)
 
-    @patch.object(juju_test.Orchestra, 'rsync')
-    @patch.object(juju_test.Conductor, 'status')
+    @patch.object(charm_test.Orchestra, 'rsync')
+    @patch.object(charm_test.Conductor, 'status')
     def test_orchestra_archive_logs_go(self, mstatus, rsync):
         goyml_output = '''
         machines:
@@ -674,9 +674,9 @@ class JujuTestPluginTest(unittest.TestCase):
         juju_env = 'testing'
         args = Arguments(tests='dummy', juju_env=juju_env, logdir='/tmp')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=10, patch=0)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=10, patch=0)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             o.build_env()
             o.archive_logs()
@@ -689,8 +689,8 @@ class JujuTestPluginTest(unittest.TestCase):
                     os.path.join(args.logdir, 'dummy', ''))
             ])
 
-    @patch.object(juju_test.Orchestra, 'rsync')
-    @patch.object(juju_test.Conductor, 'status')
+    @patch.object(charm_test.Orchestra, 'rsync')
+    @patch.object(charm_test.Conductor, 'status')
     def test_orchestra_archive_logs_py(self, mstatus, rsync):
         pyyml_output = '''
         machines:
@@ -719,9 +719,9 @@ class JujuTestPluginTest(unittest.TestCase):
         juju_env = 'testing'
         args = Arguments(tests='dummy', juju_env=juju_env, logdir='/tmp')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=0, minor=7, patch=0)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=0, minor=7, patch=0)
+            o = charm_test.Orchestra(c, 'test/dummy')
 
             o.build_env()
             o.archive_logs()
@@ -737,20 +737,20 @@ class JujuTestPluginTest(unittest.TestCase):
                     os.path.join(args.logdir, 'dummy', ''))
             ])
 
-    @patch.object(juju_test.Conductor, 'status')
+    @patch.object(charm_test.Conductor, 'status')
     def test_orchestra_archive_logs_status_fails(self, mstatus):
         mstatus.return_value = None
 
         args = Arguments(tests='dummy', juju_env='testing', logdir='/tmp')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            o = charm_test.Orchestra(c, 'test/dummy')
             o.build_env()
 
-            self.assertRaises(juju_test.OrchestraError, o.archive_logs)
+            self.assertRaises(charm_test.OrchestraError, o.archive_logs)
 
-    @patch.object(juju_test.Orchestra, 'rsync')
-    @patch.object(juju_test.Conductor, 'status')
+    @patch.object(charm_test.Orchestra, 'rsync')
+    @patch.object(charm_test.Conductor, 'status')
     def test_orchestra_archive_logs_rsync_fails(self, mstatus, rsync):
         from subprocess import CalledProcessError
         mstatus.return_value = {'services': {'dummy': {'units': {'dummy/0':
@@ -758,9 +758,9 @@ class JujuTestPluginTest(unittest.TestCase):
 
         args = Arguments(tests='dummy', juju_env='testing', logdir='/tmp')
         with cd('tests_functional/charms/test/'):
-            c = juju_test.Conductor(args)
-            c.juju_version = juju_test.JujuVersion(major=1, minor=7, patch=0)
-            o = juju_test.Orchestra(c, 'test/dummy')
+            c = charm_test.Conductor(args)
+            c.juju_version = charm_test.JujuVersion(major=1, minor=7, patch=0)
+            o = charm_test.Orchestra(c, 'test/dummy')
             o.log.warn = MagicMock()
             o.build_env()
 
@@ -782,16 +782,16 @@ class TestCfgTest(unittest.TestCase):
     '''
 
     def test_init_str(self):
-        t = juju_test.TestCfg(self.test_config)
+        t = charm_test.TestCfg(self.test_config)
         self.assertEqual(t.timeout, 500)
         self.assertEqual(t.substrates['include'], 'local')
 
     def test_init_dict(self):
-        t = juju_test.TestCfg(yaml.safe_load(self.test_config))
+        t = charm_test.TestCfg(yaml.safe_load(self.test_config))
         self.assertEqual(t.timeout, 500)
         self.assertEqual(t.substrates['include'], 'local')
 
     def test_update(self):
-        t = juju_test.TestCfg(self.test_config)
+        t = charm_test.TestCfg(self.test_config)
         t.update(timeout=400)
         self.assertEqual(t.timeout, 400)


### PR DESCRIPTION
## Checklist

 - [-] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
        This site no longer resolves.
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?

Re-add the formerly removed juju-test command, also aliasing it as charm-test, so it can be called from the 'charm' binary, to make it easier to use when installed as a snap.

`juju-test` is important as it's used by many charms as a way to run unit tests. It's trivial to update these to `charm-test`, or `charm test`, however `juju-test` is a Juju plugin which people rely on, and when it disappeared, it caused much confusion.

This commit re-adds the command, and adds charm-test. I have also renamed the unit tests to refer to the new 'charm test' name, and tested that they work. They do.