### PR TITLE
Purge duplicate wheels for module when overriding

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -346,6 +346,7 @@ class Builder(object):
                 layers["layers"][-1],
                 next_config,
             )
+            output_files['wheelhouse.txt'].purge_wheels = True
             if existing_tactic is not None:
                 output_files['wheelhouse.txt'].combine(existing_tactic)
         plan = [t for t in output_files.values() if t]

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -769,6 +769,7 @@ class WheelhouseTactic(ExactMatch, Tactic):
         self.tracked = []
         self.previous = []
         self._venv = None
+        self.purge_wheels = False
 
     def __str__(self):
         directory = self.target.directory / 'wheelhouse'
@@ -785,7 +786,12 @@ class WheelhouseTactic(ExactMatch, Tactic):
                       *reqs)
             for wheel in temp_dir.files():
                 dest = wheelhouse / wheel.basename()
-                dest.remove_p()
+                if self.purge_wheels:
+                    unversioned_wheel = wheel.basename().split('-')[0]
+                    for old_wheel in wheelhouse.glob(unversioned_wheel + '-*'):
+                        old_wheel.remove()
+                else:
+                    dest.remove_p()
                 wheel.move(wheelhouse)
                 self.tracked.append(dest)
 


### PR DESCRIPTION
When the --wheelhouse-overrides option is used, duplicate wheels can
be produced in the resulting wheelhouse if the version pulled in by
the override wheelhouse is different from the version pulled in
during the regular build.

With this patch when the override wheelhouse is being processed it
removes any existing wheelhouses for the module being added. Since
the override wheelhouse is processed last the modules specified in
it are always the copies from the override.

Looking at wheel package format *1 hypens are replaced with
underscores in the distribution name and then hypens are used as
delimiters in the wheel file name *2:
{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform
tag}.whl.
Given that I think deleting wheels that match {distribution}-* is
safe.

*1 https://www.python.org/dev/peps/pep-0427/#escaping-and-unicode
*2 https://www.python.org/dev/peps/pep-0427/#file-name-convention

closes #381
