### PR TITLE
Capture errors when user is not in /etc/passwd fixes #383

### DIFF
--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -603,7 +603,12 @@ def get_home():
 
     If the home directory can't be determined, it will return None.
     """
-    username = pwd.getpwuid(os.getuid()).pw_name
+
+    try:
+        username = pwd.getpwuid(os.getuid()).pw_name
+    except KeyError:
+        return None
+
     home = os.path.expanduser('~{}'.format(username))
     if home.startswith('~'):
         return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,3 +49,8 @@ class TestUtils(TestCase):
         assert utils.get_home() == os.path.expanduser('~')
         with mock.patch('os.path.expanduser', lambda u: u):
             assert utils.get_home() is None
+
+    def test_get_no_home(self):
+        # some uids don't have pw_names
+        with mock.patch('os.getuid', lambda: 12):
+            self.assertIs(utils.get_home(), None)


### PR DESCRIPTION
Addresses issues in #383 when the user isn't a proper full system uid

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
