### PR TITLE
Improve error checking and reporting around home dir

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -520,14 +520,14 @@ class Builder(object):
         a, c, d = utils.delta_signatures(self.manifest)
 
         for f in a:
-            log.warn(
-                "Conflict: File in destination directory was added after charm build: %s", f)
+            log.warn("Conflict: File in destination directory "
+                     "was added after charm build: %s", f)
         for f in c:
-            log.warn(
-                "Conflict: File in destination directory was modified after charm build: %s", f)
+            log.warn("Conflict: File in destination directory "
+                     "was modified after charm build: %s", f)
         for f in d:
-            log.warn(
-                "Conflict: File in destination directory was deleted after charm build: %s", f)
+            log.warn("Conflict: File in destination directory "
+                     "was deleted after charm build: %s", f)
         if a or c or d:
             if self.force is True:
                 log.info(
@@ -577,27 +577,31 @@ class Builder(object):
             od = od.basename
         self.output_dir = od
 
-    def _check_path(self, path_to_check):
+    def _check_path(self, path_to_check, need_write=False):
         home_dir = utils.get_home()
+        home_msg = ('For security reasons, only paths under your '
+                    'home directory can be accessed, including '
+                    'the build output dir, JUJU_REPOSITORY, '
+                    'LAYER_PATH, INTERFACE_PATH, and any '
+                    'wheelhouse overrides.')
         if not home_dir:  # expansion failed
-            raise BuildError('Could not determine home directory')
-        return os.path.abspath(path_to_check).startswith(home_dir)
+            log.warn('Could not determine home directory.')
+            log.warn(home_msg)
+        elif os.path.abspath(path_to_check).startswith(home_dir):
+            log.warn('The path {} is not under your '
+                     'home directory.'.format(home_dir))
+            log.warn(home_msg)
+        if not os.access(path_to_check, os.R_OK):
+            raise BuildError('Unable to read from: {}'.format(path_to_check))
+        if need_write and not os.access(path_to_check, os.W_OK):
+            raise BuildError('Unable to write to: {}'.format(path_to_check))
 
     def check_paths(self):
-        paths_to_check = [
-            self.output_dir,
-            self.wheelhouse_overrides,
-            os.environ.get('JUJU_REPOSITORY'),
-            os.environ.get('LAYER_PATH'),
-            os.environ.get('INTERACE_PATH'),
-        ]
-        for path_to_check in paths_to_check:
-            if path_to_check and not self._check_path(path_to_check):
-                raise BuildError('For security reasons, only paths under your '
-                                 'home directory can be accessed, including '
-                                 'the build output dir, JUJU_REPOSITORY, '
-                                 'LAYER_PATH, INTERFACE_PATH, and any '
-                                 'wheelhouse overrides')
+        self._check_path(self.output_dir, need_write=True)
+        self._check_path(self.wheelhouse_overrides)
+        self._check_path(os.environ.get('JUJU_REPOSITORY'))
+        self._check_path(os.environ.get('LAYER_PATH'))
+        self._check_path(os.environ.get('INTERACE_PATH'))
 
     def clean_removed(self, signatures):
         """

--- a/charmtools/create.py
+++ b/charmtools/create.py
@@ -98,7 +98,7 @@ def main():
         generator.create_charm()
         return 0
     except CharmGeneratorException as e:
-        log.error(e)
+        log.error(str(e))
         return 1
 
 

--- a/charmtools/proof.py
+++ b/charmtools/proof.py
@@ -38,13 +38,23 @@ def get_args(args=None):
 
 
 def proof(path, is_bundle, debug):
+    messages = []
+    exit_code = 0
     path = os.path.abspath(path)
     home_path = utils.get_home()
+    home_msg = ('For security reasons, only paths under '
+                'your home directory can be accessed')
     if not home_path:  # expansion failed
-        return ['Could not determine home directory'], 200
-    if not path.startswith(home_path):
-        return ['For security reasons, only paths under '
-                'your home directory can be accessed'], 200
+        messages.append('Could not determine home directory')
+        messages.append(home_msg)
+    elif not path.startswith(home_path):
+        messages.append('The path {} is not under your '
+                        'home directory'.format(path))
+        messages.append(home_msg)
+    if not os.access(path, os.R_OK):
+        messages.append('Unable to read from {}'.format(path))
+        exit_code = 200
+        return messages, exit_code
     if not is_bundle:
         try:
             c = Charm(path)

--- a/charmtools/pullsource.py
+++ b/charmtools/pullsource.py
@@ -162,12 +162,16 @@ def download_item(item, dir_):
     dir_ = os.path.abspath(os.path.expanduser(dir_))
 
     home_path = utils.get_home()
+    home_msg = ('For security reasons, only paths under '
+                'your home directory can be accessed')
     if not home_path:  # expansion failed
         print('Could not determine home directory')
-        return 200
-    if not dir_.startswith(home_path):
-        print('For security reasons, only paths under '
-              'your home directory can be accessed')
+        print(home_msg)
+    elif not dir_.startswith(home_path):
+        print('The path {} is not under your home directory'.format(home_path))
+        print(home_msg)
+    if not os.access(dir_, os.W_OK):
+        print('Unable to write to {}'.format(dir_))
         return 200
 
     # Create series dir if we need to

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -283,7 +283,7 @@ def retry(attempts, *callbacks, **kwargs):
     """
     Repeatedly try callbacks a fixed number of times or until all return True
     """
-    for attempt in xrange(attempts):
+    for attempt in range(attempts):
         if 'bar' in kwargs:
             kwargs['bar'].next(attempt == 0, message=kwargs.get('message'))
         for callback in callbacks:
@@ -606,7 +606,7 @@ def get_home():
 
     try:
         username = pwd.getpwuid(os.getuid()).pw_name
-    except KeyError:
+    except Exception:
         return None
 
     home = os.path.expanduser('~{}'.format(username))

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -83,7 +83,7 @@ class CharmGeneratorTest(TestCase):
                 'summary': 'Charm summary',
                 'description': 'Charm description'})
 
-    @patch('__builtin__.raw_input')
+    @patch('charmtools.generators.generator.rinput')
     def test_get_user_config_from_prompts(self, raw_input_):
         raw_input_.return_value = 'Yes'
         with patch.object(self.c.plugin, 'prompts') as prompts:
@@ -114,14 +114,14 @@ class CharmGeneratorTest(TestCase):
 
         self.assertTrue(self.c._prompt(prompt, {}))
 
-    @patch('__builtin__.raw_input')
+    @patch('charmtools.generators.generator.rinput')
     def test_prompt_no_input(self, raw_input_):
         raw_input_.return_value = ''
         prompt = Prompt('symlink', 'symlink hooks?', 'y', 'bool')
 
         self.assertTrue(self.c._prompt(prompt, {}))
 
-    @patch('__builtin__.raw_input')
+    @patch('charmtools.generators.generator.rinput')
     def test_prompt_invalid_input(self, raw_input_):
         raw_input_.side_effect = ['foo', '18']
         prompt = Prompt('age', 'your age?', '42', 'int')
@@ -129,7 +129,7 @@ class CharmGeneratorTest(TestCase):
         self.assertEqual(self.c._prompt(prompt, {}), 18)
         self.assertEqual(raw_input_.call_count, 2)
 
-    @patch('__builtin__.raw_input')
+    @patch('charmtools.generators.generator.rinput')
     def test_prompt_valid_input(self, raw_input_):
         raw_input_.return_value = 'Joe'
         prompt = Prompt('name', 'your name?', 'Name')


### PR DESCRIPTION
Makes the home dir check non-fatal but follows it with a hard check for permissions, which is what we ultimately care about.  This allows for cases where we can't determine the home dir but the user is doing the right thing.

Fixes #383

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
