### PR TITLE
Add support for, and validation of display-name property

### DIFF
--- a/charmtools/bundles.py
+++ b/charmtools/bundles.py
@@ -5,6 +5,7 @@ import yaml
 
 from linter import Linter
 import jujubundlelib.validation
+from charmtools.utils import validate_display_name
 
 
 charm_url_includes_id = re.compile(r'-\d+$').search
@@ -15,6 +16,7 @@ class BundleLinter(Linter):
         """Supplement jujubundlelib validation with some extra checks.
 
         """
+        validate_display_name(data, self)
         if 'series' not in data and 'inherits' not in data:
             self.info("No series defined")
 

--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -11,6 +11,7 @@ from stat import S_IXUSR
 
 from linter import Linter
 from launchpadlib.launchpad import Launchpad
+from charmtools.utils import validate_display_name
 
 KNOWN_METADATA_KEYS = [
     'name',
@@ -735,23 +736,6 @@ def validate_actions(actions, action_hooks, linter):
             linter.warn('actions.{0}: actions/{0} does not exist'.format(k))
         elif not os.access(h, os.X_OK):
             linter.err('actions.{0}: actions/{0} is not executable'.format(k))
-
-def validate_display_name(charm, linter):
-    """Validate the display name info in charm metadata.
-
-    :param charm: dict of charm metadata parsed from metadata.yaml
-    :param linter: :class:`CharmLinter` object to which info/warning/error
-        messages will be written
-    """
-    if 'display-name' not in charm:
-        linter.info(
-            '`display-name` not provided, charm will be displayed as "%s"' % charm['name'])
-        return
-
-    match = re.match(r'(\w+\s*)+', charm['display-name'])
-    if not match:
-        linter.err('display-name: not in valid format (\w+\s*)+')
-        return
 
 def validate_maintainer(charm, linter):
     """Validate maintainer info in charm metadata.

--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -14,6 +14,7 @@ from launchpadlib.launchpad import Launchpad
 
 KNOWN_METADATA_KEYS = [
     'name',
+    'display-name',
     'summary',
     'maintainer',
     'maintainers',
@@ -289,6 +290,7 @@ class Charm(object):
             if len(charm['summary']) > 72:
                 lint.warn('summary should be less than 72')
 
+            validate_display_name(charm, lint)
             validate_maintainer(charm, lint)
             validate_categories_and_tags(charm, lint)
             validate_storage(charm, lint)
@@ -734,6 +736,22 @@ def validate_actions(actions, action_hooks, linter):
         elif not os.access(h, os.X_OK):
             linter.err('actions.{0}: actions/{0} is not executable'.format(k))
 
+def validate_display_name(charm, linter):
+    """Validate the display name info in charm metadata.
+
+    :param charm: dict of charm metadata parsed from metadata.yaml
+    :param linter: :class:`CharmLinter` object to which info/warning/error
+        messages will be written
+    """
+    if 'display-name' not in charm:
+        linter.info(
+            '`display-name` not provided, charm will be displayed as "%s"' % charm['name'])
+        return
+
+    match = re.match(r'(\w+\s*)+', charm['display-name'])
+    if not match:
+        linter.err('display-name: not in valid format (\w+\s*)+')
+        return
 
 def validate_maintainer(charm, linter):
     """Validate maintainer info in charm metadata.

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -613,3 +613,19 @@ def get_home():
     if home.startswith('~'):
         return None
     return home
+
+def validate_display_name(entity, linter):
+    """Validate the display name info in entity metadata.
+
+    :param entity: dict of entity metadata parsed from metadata.yaml
+    :param linter: :class:`CharmLinter` or :class: `BundleLinter` object to
+        which info/warning/error messages will be written
+    """
+    if 'display-name' not in entity:
+        linter.info('`display-name` not provided, add for custom naming in the UI')
+        return
+
+    match = re.match(r'(\w+\s*)+', entity['display-name'])
+    if not match:
+        linter.err('display-name: not in valid format (\w+\s*)+')
+        return

--- a/tests/test_bundle_proof.py
+++ b/tests/test_bundle_proof.py
@@ -81,3 +81,25 @@ class TestCharmProof(unittest.TestCase):
             'W: my-service: memcached: No annotations found, will render '
             'poorly in GUI',
             self.linter.lint)
+
+    def test_hints_about_missing_display_name(self):
+        self.linter.validate({
+            'services': {
+                'memcached': {
+                    'charm': 'cs:precise/memcached',
+                    'num_units': 1,
+                },
+            }
+        })
+        self.assertIn('I: `display-name` not provided, add for custom naming in the UI',
+            self.linter.lint)
+
+    def test_allows_display_name(self):
+        self.linter.validate({'display-name': 'Peanut Butter'})
+        self.assertNotIn('E: display-name: not in valid format (\w+\s*)+',
+            self.linter.lint)
+
+    def test_validates_display_name(self):
+        self.linter.validate({'display-name': '<Peanut$!Butter>'})
+        self.assertIn('E: display-name: not in valid format (\w+\s*)+',
+            self.linter.lint)

--- a/tests/test_charm_proof.py
+++ b/tests/test_charm_proof.py
@@ -30,6 +30,7 @@ proof_path = join(proof_path, 'charmtools')
 sys.path.append(proof_path)
 
 from charmtools.charms import CharmLinter as Linter
+from charmtools.charms import validate_display_name
 from charmtools.charms import validate_maintainer
 from charmtools.charms import validate_categories_and_tags
 from charmtools.charms import validate_storage
@@ -396,6 +397,38 @@ class CategoriesTagsValidationTest(TestCase):
         self.assertFalse(linter.info.called)
         self.assertFalse(linter.err.called)
 
+
+class DisplayNameValidationTest(TestCase):
+    def test_educates_display_name(self):
+        """Charm does not have a display_name."""
+        linter = Mock()
+        charm = {
+            'name': 'peanutbutter'
+        }
+        validate_display_name(charm, linter)
+        linter.info.assert_called_once_with(
+            '`display-name` not provided, charm will be displayed as "peanutbutter"')
+
+    def test_allows_display_name(self):
+        """Charm has a display_name."""
+        linter = Mock()
+        charm = {
+            'display-name': 'Peanut Butter'
+        }
+        validate_display_name(charm, linter)
+        linter.info.assert_not_called()
+        linter.err.assert_not_called()
+        linter.warn.assert_not_called()
+
+    def test_display_name_alphanumeric_only(self):
+        """Charm had invalid display_name."""
+        linter = Mock()
+        charm = {
+            'display-name': '<Peanut$!Butter>'
+        }
+        validate_display_name(charm, linter)
+        linter.err.assert_called_once_with(
+            'display-name: not in valid format (\w+\s*)+')
 
 class MaintainerValidationTest(TestCase):
     def test_two_maintainer_fields(self):

--- a/tests/test_charm_proof.py
+++ b/tests/test_charm_proof.py
@@ -407,7 +407,7 @@ class DisplayNameValidationTest(TestCase):
         }
         validate_display_name(charm, linter)
         linter.info.assert_called_once_with(
-            '`display-name` not provided, charm will be displayed as "peanutbutter"')
+            '`display-name` not provided, add for custom naming in the UI')
 
     def test_allows_display_name(self):
         """Charm has a display_name."""


### PR DESCRIPTION
In order for correct presentation of charm names in the GUI and jujucharms.com this adds support for a `display-name` property. This will be used by charm authors to provide the correct spacing and casing for their charms ex) `PostgreSQL` instead of `postgresql`