### PR TITLE
allow applications key for charm proof (fixes #390)

### DIFF
--- a/charmtools/bundles.py
+++ b/charmtools/bundles.py
@@ -21,7 +21,12 @@ class BundleLinter(Linter):
             self.info("No series defined")
 
         if 'services' in data:
-            for svc, sdata in data['services'].items():
+            app_key = 'services'
+        else:
+            app_key = 'applications'
+
+        if app_key in data:
+            for svc, sdata in data[app_key].items():
                 if 'annotations' not in sdata:
                     self.warn('%s: No annotations found, will render '
                               'poorly in GUI' % svc)
@@ -31,7 +36,7 @@ class BundleLinter(Linter):
                         '%s: charm URL should include a revision' % svc)
         else:
             if 'inherits' not in data:
-                self.err("No services defined")
+                self.err("No applications defined")
 
     def proof(self, bundle):
         data = bundle.bundle_file()
@@ -77,7 +82,7 @@ class Bundle(object):
     def is_v4(self, data=None):
         if data is None:
             data = self.bundle_file()
-        v4_keys = {'services', 'relations', 'machines', 'series'}
+        v4_keys = {'applications', 'services', 'relations', 'machines', 'series'}
         bundle_keys = set(data.keys())
         return bool(v4_keys & bundle_keys)
 

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -208,6 +208,7 @@ class Process(object):
             result.exit_on_error()
         return result
 
+
 command = Process
 
 
@@ -440,6 +441,7 @@ class _O(dict):
     def __getattr__(self, k):
         return self[k]
 
+
 REACTIVE_PATTERNS = [
     re.compile("\s*@when"),
     re.compile(".set_state\(")
@@ -613,6 +615,7 @@ def get_home():
     if home.startswith('~'):
         return None
     return home
+
 
 def validate_display_name(entity, linter):
     """Validate the display name info in entity metadata.

--- a/tests/test_bundle_proof.py
+++ b/tests/test_bundle_proof.py
@@ -23,7 +23,33 @@ class TestCharmProof(unittest.TestCase):
     def setUp(self):
         self.linter = charmtools.bundles.BundleLinter()
 
-    def test_warn_on_charm_urls_without_revisions(self):
+    def test_invalid_app_key(self):
+        self.linter.validate({
+            'invalid': {
+                'memcached': {
+                    'charm': 'cs:precise/memcached',
+                    'num_units': 1,
+                },
+            }
+        })
+        self.assertIn(
+            'E: No applications defined',
+            self.linter.lint)
+
+    def test_applications_warn_on_charm_urls_without_revisions(self):
+        self.linter.validate({
+            'applications': {
+                'memcached': {
+                    'charm': 'cs:precise/memcached',
+                    'num_units': 1,
+                },
+            }
+        })
+        self.assertIn(
+            'W: memcached: charm URL should include a revision',
+            self.linter.lint)
+
+    def test_services_warn_on_charm_urls_without_revisions(self):
         self.linter.validate({
             'services': {
                 'memcached': {

--- a/tests/test_bundle_proof.py
+++ b/tests/test_bundle_proof.py
@@ -92,7 +92,7 @@ class TestCharmProof(unittest.TestCase):
             }
         })
         self.assertIn('I: `display-name` not provided, add for custom naming in the UI',
-            self.linter.lint)
+                      self.linter.lint)
 
     def test_allows_valid_display_name(self):
         # These names are copied from the juju/names package tests.
@@ -106,8 +106,9 @@ class TestCharmProof(unittest.TestCase):
         ]
         for name in valid_names:
             self.linter.validate({'display-name': name})
-            self.assertNotIn('E: display-name: not in valid format. Only letters, numbers, dashes, and hyphens are permitted.',
-                self.linter.lint)
+            self.assertNotIn('E: display-name: not in valid format. '
+                             'Only letters, numbers, dashes, and hyphens are permitted.',
+                             self.linter.lint)
 
     def test_validates_display_name(self):
         # These names are copied from the juju/names package tests.
@@ -122,5 +123,6 @@ class TestCharmProof(unittest.TestCase):
         ]
         for name in invalid_names:
             self.linter.validate({'display-name': name})
-            self.assertIn('E: display-name: not in valid format. Only letters, numbers, dashes, and hyphens are permitted.',
-                self.linter.lint)
+            self.assertIn('E: display-name: not in valid format. '
+                          'Only letters, numbers, dashes, and hyphens are permitted.',
+                          self.linter.lint)


### PR DESCRIPTION
Allow `charm proof` to accept either `services` or `applications` in a bundle. Also fix up minor lint issues in utils and test_bundle_proof.

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
