### PR TITLE
Fix snap build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 
 version_script = os.path.join(os.path.dirname(__file__), 'charmtools', 'git_version.py')
-version = subprocess.check_output([version_script, '--format=short']).strip()
+version = subprocess.check_output([sys.executable, version_script, '--format=short']).strip()
 if sys.version_info >= (3, 0):
     version = version.decode('UTF-8')
 


### PR DESCRIPTION
Ensure that the version script is run with the same Python executable as the setup.py.  This fixes the snap build where there is a Python 2 executable on the path during install but we want to be using a specific Python 3 executable.