### PR TITLE
Add support for {pre,post}-series-upgrade hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ man
 *.sw[nop]
 .venv/
 *.snap
+charm_source.tar.bz2
 parts/
 prime/
 stage/

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -382,6 +382,8 @@ class StandardHooksBind(DynamicHookBind):
         'stop',
         'update-status',
         'upgrade-charm',
+        'pre-series-upgrade',
+        'post-series-upgrade',
     ]
 
 


### PR DESCRIPTION
In-progress support for handling series upgrade (e.g., trusty -> xenial)