### PR TITLE
Support charms.reactive layer options

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -579,6 +579,7 @@ class LayerYAML(YAMLTactic):
         defined_layer_names = set(self.schema['properties'].keys())
         options_layer_names = set(self.data['options'].keys())
         unknown_layer_names = options_layer_names - defined_layer_names
+        unknown_layer_names -= {'charms.reactive'}
         if unknown_layer_names:
             log.error('Options set for undefined layer{s}: {layers}'.format(
                 s='s' if len(unknown_layer_names) > 1 else '',


### PR DESCRIPTION
Allow for the reactive library to have its own options section even though it's not a layer by itself.  We might want to support a more generic way of handling this, so that arbitrary libraries can defined
their own sections, perhaps via entry points, but this is a quick fix for the reactive library itself.