### PR TITLE
Support subdir field in layer index

### DIFF
--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -109,8 +109,13 @@ class InterfaceFetcher(fetchers.LocalFetcher):
             f, target = self._get_repo_fetcher_and_target(self.repo, dir_)
             res = f.fetch(dir_)
             if res != target:
+                res = path(res)
+                if hasattr(self, 'subdir'):
+                    res = res / self.subdir
                 target.rmtree_p()
-                path(res).rename(target)
+                # call this way instead of `res.rename(target)`
+                # to make unit test easier
+                path.rename(res, target)
             return target
 
 fetchers.FETCHERS.insert(0, InterfaceFetcher)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ install_command =  pip install {opts} {packages}
 passenv = TERM
 commands = pip install -e {toxinidir}
            coverage erase
-           coverage run --include=charmtools/* {envbindir}/nosetests {posargs}
+           coverage run --include=charmtools/* {envbindir}/nosetests -s {posargs}
            coverage report
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
To support layers and interfaces being nested inside larger repos instead of repos on their own, this adds support for a `subdir` field in the layer index.

Fixes #212

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
