### PR TITLE
Fix "no attribute parser" masking actual YAML parsing error

### DIFF
--- a/charmtools/build/config.py
+++ b/charmtools/build/config.py
@@ -50,11 +50,12 @@ class BuildConfig(chainstuf):
         if not config_file.exists() and not allow_missing:
             raise OSError("Missing Config File {}".format(config_file))
         try:
-            if config_file.exists() and config_file.text('utf-8').strip() != "":
+            if config_file.exists() and config_file.text('utf-8').strip():
                 data = yaml.safe_load(config_file.open(encoding='utf-8'))
                 self.configured = True
-        except yaml.parser.ParserError:
-            logging.critical("Malformed Config file: {}".format(config_file))
+        except yaml.error.YAMLError as e:
+            logging.critical("Malformed config file {}: {}".format(config_file,
+                                                                   e))
             raise
         if data:
             self.update(data)


### PR DESCRIPTION
The builder uses ruamel rather than pyyaml, which uses a different exception.

Fixes #428