### PR TITLE
Report detailed version for charmstore-client

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -26,7 +26,7 @@ from charmtools.build.fetchers import (
     get_fetcher,
     FetchError,
 )
-from charmtools.version import charm_tools_version
+from charmtools.version import cached_charm_tools_version, format_version
 
 log = logging.getLogger("build")
 
@@ -523,7 +523,7 @@ class Builder(object):
                 't': 'event',
                 'ds': 'app',
                 'cid': cid,
-                'av': charm_tools_version('long'),
+                'av': format_version(cached_charm_tools_version(), 'long'),
                 'an': "charm-build",
                 'ec': kind,
                 'ea': 'fetch' if fetched else 'local',

--- a/charmtools/git_version.py
+++ b/charmtools/git_version.py
@@ -39,14 +39,10 @@ def _scm_version(repo_path):
 def format_version(version_info, ver_format):
     if ver_format == 'json':
         return json.dumps(version_info)
-    if 'SNAP_REVISION' in os.environ:
-        snap = '+snap-{}'.format(os.environ['SNAP_REVISION'])
-    else:
-        snap = ''
     pre_release = version_info.get('pre_release') or version_info.get('gitn')
     if ver_format == 'long' or (ver_format == 'default' and pre_release):
         return '{version}{snap}{git}'.format(version=version_info['version'],
-                                             snap=snap,
+                                             snap=version_info.get('snap', ''),
                                              git=version_info.get('git', ''))
     else:
         return version_info['version']

--- a/charmtools/git_version.py
+++ b/charmtools/git_version.py
@@ -3,17 +3,19 @@
 from __future__ import print_function
 
 import argparse
-import json
 import os
 import sys
+import json
 from subprocess import check_output, CalledProcessError, PIPE
-from pkg_resources import parse_version, resource_string, resource_exists
+from pkg_resources import parse_version
 
 
 git_cmd = ['git', 'describe', '--tags', '--long']
 
 
-def _scm_version(name):
+def _scm_version(repo_path):
+    old_dir = os.getcwd()
+    os.chdir(repo_path)
     try:
         output = check_output(git_cmd, stderr=PIPE)
         if sys.version_info >= (3, 0):
@@ -21,95 +23,44 @@ def _scm_version(name):
         version, gitn, gitsha = output.strip().rsplit('-', 2)
         if version.startswith('v'):
             version = version[1:]
+        pv = parse_version(version)
         return {
             'version': version,
             'git': '+git-{}-{}'.format(gitn, gitsha),
             'gitn': int(gitn),
+            'pre_release':  pv.is_prerelease,
         }
     except CalledProcessError:
-        print("Unable to determine {} version".format(name), file=sys.stderr)
-        return {
-            'version': '0.0.0',
-            'git': '',
-            'gitn': 0,
-        }
-
-
-def _add_pre_rel(version_info):
-    pv = parse_version(version_info['version'])
-    version_info['pre_release'] = pv.is_prerelease
-
-
-def _add_snap_rev(version_info):
-    # snap rev is not available at build time, so we can never cache it
-    snaprev = os.environ.get('SNAP_REVISION', None)
-    version_info['snap'] = '+snap-{}'.format(snaprev) if snaprev else ''
-
-
-def get_version_info():
-    if resource_exists(__name__, 'VERSION'):
-        res_string = resource_string(__name__, 'VERSION')
-        if sys.version_info >= (3, 0):
-            res_string = res_string.decode('UTF-8')
-        version_info = json.loads(res_string)
-    elif os.environ.get('SNAPCRAFT_PROJECT_VERSION', 'git') != 'git':
-        version_parts = os.environ['SNAPCRAFT_PROJECT_VERSION'].split('+')
-        git = ''
-        gitn = 0
-        if len(version_parts) > 1:
-            git = version_parts[1]
-            gitn = int(git.split('-')[1])
-        version_info = {
-            'version': version_parts[0],
-            'git': '+{}'.format(git),
-            'gitn': gitn,
-        }
-    else:
-        version_info = _scm_version('charm-tools')
-
-    _add_pre_rel(version_info)
-    _add_snap_rev(version_info)
-
-    return version_info
-
-
-def _build_charm_version():
-    old_dir = os.getcwd()
-    os.chdir('../parts/charmstore-client/src')
-    try:
-        version_info = _scm_version('charmstore-client')
+        return {'version': 'unknown'}
     finally:
         os.chdir(old_dir)
 
-    _add_pre_rel(version_info)
-    version_info['snap'] = ''  # no snap rev for charmstore part
 
-    with open('charmstore-client-version', 'w') as fh:
-        json.dump(version_info, fh)
-
-
-def _get_charm_tools_version():
-    version_info = get_version_info()
-
-    version_filename = os.path.join(os.path.dirname(__file__), 'VERSION')
-    with open(version_filename, 'w') as fh:
-        # cache version info in case git info is unavailable
-        json.dump(version_info, fh)
-
-    pre_release = version_info['pre_release'] or version_info['gitn']
-    if args.format == 'long' or (args.format == 'default' and pre_release):
-        print('{version}{git}'.format(**version_info))
+def format_version(version_info, ver_format):
+    if ver_format == 'json':
+        return json.dumps(version_info)
+    if 'SNAP_REVISION' in os.environ:
+        snap = '+snap-{}'.format(os.environ['SNAP_REVISION'])
     else:
-        print(version_info['version'])
+        snap = ''
+    pre_release = version_info.get('pre_release') or version_info.get('gitn')
+    if ver_format == 'long' or (ver_format == 'default' and pre_release):
+        return '{version}{snap}{git}'.format(version=version_info['version'],
+                                             snap=snap,
+                                             git=version_info.get('git', ''))
+    else:
+        return version_info['version']
 
 
 def get_args(args=None):
-    parser = argparse.ArgumentParser(description='Determine version')
-    parser.add_argument('--format', choices=['long', 'short', 'default'],
+    parser = argparse.ArgumentParser(description='Determine version from git')
+    parser.add_argument('path', nargs='?', default='.',
+                        help='Path of repo to inspect')
+    parser.add_argument('--format',
+                        choices=['long', 'short', 'default', 'json'],
                         default='default',
                         help="Version format. Long includes git revision "
                              "info. Default uses long if it's a pre-release.")
-    parser.add_argument('--build-charm-version', action='store_true')
     args = parser.parse_args(args)
 
     return args
@@ -117,7 +68,4 @@ def get_args(args=None):
 
 if __name__ == '__main__':
     args = get_args()
-    if args.build_charm_version:
-        _build_charm_version()
-    else:
-        _get_charm_tools_version()
+    print(format_version(_scm_version(args.path), args.format))

--- a/charmtools/git_version.py
+++ b/charmtools/git_version.py
@@ -13,6 +13,39 @@ from pkg_resources import parse_version, resource_string, resource_exists
 git_cmd = ['git', 'describe', '--tags', '--long']
 
 
+def _scm_version(name):
+    try:
+        output = check_output(git_cmd, stderr=PIPE)
+        if sys.version_info >= (3, 0):
+            output = output.decode('UTF-8')
+        version, gitn, gitsha = output.strip().rsplit('-', 2)
+        if version.startswith('v'):
+            version = version[1:]
+        return {
+            'version': version,
+            'git': '+git-{}-{}'.format(gitn, gitsha),
+            'gitn': int(gitn),
+        }
+    except CalledProcessError:
+        print("Unable to determine {} version".format(name), file=sys.stderr)
+        return {
+            'version': '0.0.0',
+            'git': '',
+            'gitn': 0,
+        }
+
+
+def _add_pre_rel(version_info):
+    pv = parse_version(version_info['version'])
+    version_info['pre_release'] = pv.is_prerelease
+
+
+def _add_snap_rev(version_info):
+    # snap rev is not available at build time, so we can never cache it
+    snaprev = os.environ.get('SNAP_REVISION', None)
+    version_info['snap'] = '+snap-{}'.format(snaprev) if snaprev else ''
+
+
 def get_version_info():
     if resource_exists(__name__, 'VERSION'):
         res_string = resource_string(__name__, 'VERSION')
@@ -32,50 +65,30 @@ def get_version_info():
             'gitn': gitn,
         }
     else:
-        try:
-            output = check_output(git_cmd, stderr=PIPE)
-            if sys.version_info >= (3, 0):
-                output = output.decode('UTF-8')
-            version, gitn, gitsha = output.strip().rsplit('-', 2)
-            if version.startswith('v'):
-                version = version[1:]
-            version_info = {
-                'version': version,
-                'git': '+git-{}-{}'.format(gitn, gitsha),
-                'gitn': int(gitn),
-            }
-        except CalledProcessError:
-            print("Unable to determine charm-tools version", file=sys.stderr)
-            version_info = {
-                'version': '0.0.0',
-                'snap': '',
-                'git': '',
-                'gitn': 0,
-            }
+        version_info = _scm_version('charm-tools')
 
-    pv = parse_version(version_info['version'])
-    version_info['pre_release'] = pv.is_prerelease
-
-    # snap rev is not available at build time, so we can never cache it
-    snaprev = os.environ.get('SNAP_REVISION', None)
-    version_info['snap'] = '+snap-{}'.format(snaprev) if snaprev else ''
+    _add_pre_rel(version_info)
+    _add_snap_rev(version_info)
 
     return version_info
 
 
-def get_args(args=None):
-    parser = argparse.ArgumentParser(description='Determine version')
-    parser.add_argument('--format', choices=['long', 'short', 'default'],
-                        default='default',
-                        help="Version format. Long includes git revision "
-                             "info. Default uses long if it's a pre-release.")
-    args = parser.parse_args(args)
+def _build_charm_version():
+    old_dir = os.getcwd()
+    os.chdir('../parts/charmstore-client/src')
+    try:
+        version_info = _scm_version('charmstore-client')
+    finally:
+        os.chdir(old_dir)
 
-    return args
+    _add_pre_rel(version_info)
+    version_info['snap'] = ''  # no snap rev for charmstore part
+
+    with open('charmstore-client-version', 'w') as fh:
+        json.dump(version_info, fh)
 
 
-if __name__ == '__main__':
-    args = get_args()
+def _get_charm_tools_version():
     version_info = get_version_info()
 
     version_filename = os.path.join(os.path.dirname(__file__), 'VERSION')
@@ -88,3 +101,23 @@ if __name__ == '__main__':
         print('{version}{git}'.format(**version_info))
     else:
         print(version_info['version'])
+
+
+def get_args(args=None):
+    parser = argparse.ArgumentParser(description='Determine version')
+    parser.add_argument('--format', choices=['long', 'short', 'default'],
+                        default='default',
+                        help="Version format. Long includes git revision "
+                             "info. Default uses long if it's a pre-release.")
+    parser.add_argument('--build-charm-version', action='store_true')
+    args = parser.parse_args(args)
+
+    return args
+
+
+if __name__ == '__main__':
+    args = get_args()
+    if args.build_charm_version:
+        _build_charm_version()
+    else:
+        _get_charm_tools_version()

--- a/charmtools/version.py
+++ b/charmtools/version.py
@@ -27,6 +27,11 @@ def get_args(args=None):
     return args
 
 
+def _add_snap_rev(version_info):
+    if 'SNAP_REVISION' in os.environ:
+        version_info['snap'] = '+snap-{}'.format(os.environ['SNAP_REVISION'])
+
+
 def cached_charmstore_client_version():
     if 'SNAP' in os.environ:
         cscv = os.path.join(os.environ['SNAP'], 'charmstore-client-version')
@@ -34,7 +39,7 @@ def cached_charmstore_client_version():
             return {'version': 'unavailable', 'git': ''}
         with open(cscv) as f:
             res_string = f.read().strip()
-        return json.loads(res_string)
+        return _add_snap_rev(json.loads(res_string))
     try:
         from apt.cache import Cache
         charm_vers = Cache()['charm'].versions
@@ -47,7 +52,7 @@ def cached_charmstore_client_version():
     except:
         charm_ver = 'error'
 
-    return {'version': charm_ver}
+    return _add_snap_rev({'version': charm_ver})
 
 
 def cached_charm_tools_version():
@@ -55,12 +60,12 @@ def cached_charm_tools_version():
     if os.path.exists(ctv):
         with open(ctv) as f:
             res_string = f.read().strip()
-        return json.loads(res_string)
+        return _add_snap_rev(json.loads(res_string))
     if resource_exists(__name__, 'VERSION'):
         res_string = resource_string(__name__, 'VERSION')
         if sys.version_info >= (3, 0):
             res_string = res_string.decode('UTF-8')
-        return json.loads(res_string)
+        return _add_snap_rev(json.loads(res_string))
     if os.environ.get('SNAPCRAFT_PROJECT_VERSION', 'git') != 'git':
         version_parts = os.environ['SNAPCRAFT_PROJECT_VERSION'].split('+')
         git = ''
@@ -68,11 +73,11 @@ def cached_charm_tools_version():
         if len(version_parts) > 1:
             git = version_parts[1]
             gitn = int(git.split('-')[1])
-        return {
+        return _add_snap_rev({
             'version': version_parts[0],
             'git': '+{}'.format(git),
             'gitn': gitn,
-        }
+        })
     return {'version': 'unavailable'}
 
 

--- a/charmtools/version.py
+++ b/charmtools/version.py
@@ -30,6 +30,7 @@ def get_args(args=None):
 def _add_snap_rev(version_info):
     if 'SNAP_REVISION' in os.environ:
         version_info['snap'] = '+snap-{}'.format(os.environ['SNAP_REVISION'])
+    return version_info
 
 
 def cached_charmstore_client_version():

--- a/charmtools/version.py
+++ b/charmtools/version.py
@@ -2,18 +2,21 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import os
+import sys
 import json
 import argparse
+from pkg_resources import resource_string, resource_exists
 
 from charmtools.cli import parser_defaults
 from charmtools import utils
-from charmtools.git_version import get_version_info
+from charmtools.git_version import format_version
 
 
 def get_args(args=None):
     parser = argparse.ArgumentParser(
         description='display tooling version information')
-    parser.add_argument('--format', choices=['long', 'short', 'default'],
+    parser.add_argument('--format',
+                        choices=['long', 'short', 'default', 'json'],
                         default='default',
                         help="Version format. Long includes git revision "
                              "info. Default uses long if it's a pre-release.")
@@ -24,19 +27,14 @@ def get_args(args=None):
     return args
 
 
-def charm_version(ver_format):
+def cached_charmstore_client_version():
     if 'SNAP' in os.environ:
         cscv = os.path.join(os.environ['SNAP'], 'charmstore-client-version')
         if not os.path.exists(cscv):
-            return 'unavailable'
+            return {'version': 'unavailable', 'git': ''}
         with open(cscv) as f:
             res_string = f.read().strip()
-        version_info = json.loads(res_string)
-        pre_release = version_info['pre_release'] or version_info['gitn']
-        if ver_format == 'long' or (ver_format == 'default' and pre_release):
-            return '{version}{snap}{git}'.format(**version_info)
-        else:
-            return version_info['version']
+        return json.loads(res_string)
     try:
         from apt.cache import Cache
         charm_vers = Cache()['charm'].versions
@@ -49,23 +47,48 @@ def charm_version(ver_format):
     except:
         charm_ver = 'error'
 
-    return charm_ver
+    return {'version': charm_ver}
 
 
-def charm_tools_version(ver_format):
-    version_info = get_version_info()
-    pre_release = version_info['pre_release'] or version_info['gitn']
-    if ver_format == 'long' or (ver_format == 'default' and pre_release):
-        return '{version}{snap}{git}'.format(**version_info)
-    else:
-        return version_info['version']
+def cached_charm_tools_version():
+    ctv = os.path.join(os.environ.get('SNAP', ''), 'charm-tools-version')
+    if os.path.exists(ctv):
+        with open(ctv) as f:
+            res_string = f.read().strip()
+        return json.loads(res_string)
+    if resource_exists(__name__, 'VERSION'):
+        res_string = resource_string(__name__, 'VERSION')
+        if sys.version_info >= (3, 0):
+            res_string = res_string.decode('UTF-8')
+        return json.loads(res_string)
+    if os.environ.get('SNAPCRAFT_PROJECT_VERSION', 'git') != 'git':
+        version_parts = os.environ['SNAPCRAFT_PROJECT_VERSION'].split('+')
+        git = ''
+        gitn = 0
+        if len(version_parts) > 1:
+            git = version_parts[1]
+            gitn = int(git.split('-')[1])
+        return {
+            'version': version_parts[0],
+            'git': '+{}'.format(git),
+            'gitn': gitn,
+        }
+    return {'version': 'unavailable'}
 
 
 def main():
     args = get_args()
 
-    print("charmstore-client %s" % charm_version(args.format))
-    print("charm-tools %s" % charm_tools_version(args.format))
+    if args.format == 'json':
+        print(json.dumps({
+            'charmstore-client': cached_charmstore_client_version(),
+            'charm-tools': cached_charm_tools_version(),
+        }))
+    else:
+        print("charmstore-client {}".format(
+            format_version(cached_charmstore_client_version(), args.format)))
+        print("charm-tools {}".format(
+            format_version(cached_charm_tools_version(), args.format)))
 
 
 if __name__ == '__main__':

--- a/charmtools/version.py
+++ b/charmtools/version.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import os
-import pkg_resources
+import json
 import argparse
 
 from charmtools.cli import parser_defaults
@@ -24,13 +24,19 @@ def get_args(args=None):
     return args
 
 
-def charm_version():
+def charm_version(ver_format):
     if 'SNAP' in os.environ:
         cscv = os.path.join(os.environ['SNAP'], 'charmstore-client-version')
-        if os.path.exists(cscv):
-            with open(cscv) as f:
-                charm_ver = f.read().strip()
-            return charm_ver
+        if not os.path.exists(cscv):
+            return 'unavailable'
+        with open(cscv) as f:
+            res_string = f.read().strip()
+        version_info = json.loads(res_string)
+        pre_release = version_info['pre_release'] or version_info['gitn']
+        if ver_format == 'long' or (ver_format == 'default' and pre_release):
+            return '{version}{snap}{git}'.format(**version_info)
+        else:
+            return version_info['version']
     try:
         from apt.cache import Cache
         charm_vers = Cache()['charm'].versions
@@ -58,7 +64,7 @@ def charm_tools_version(ver_format):
 def main():
     args = get_args()
 
-    print("charm %s" % charm_version())
+    print("charmstore-client %s" % charm_version(args.format))
     print("charm-tools %s" % charm_tools_version(args.format))
 
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ apps:
 parts:
   go:
     source-tag: go1.10.3
-  charm:
+  charmstore-client:
     after: [go]
     source: https://github.com/juju/charmstore-client.git
     source-branch: master
@@ -55,6 +55,7 @@ parts:
   charm-version:
     source: snap/workarounds/
     plugin: dump
-    stage:
-      - charmstore-client-version
+    override-stage: |
+      snapcraftctl stage
+      ../parts/charm-tools/build/charmtools/git_version.py --build-charm-version
     after: [charm-tools]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,7 @@ parts:
       pip download pip -d lib/python*/site-packages/virtualenv_support/
   versions:
     after: [charmstore-client, charm-tools]
-    source: snap/workarounds/
+    source: snap/
     plugin: dump
     override-stage: |
       charmtools=../parts/charm-tools/src

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,10 +52,15 @@ parts:
       snapcraftctl prime
       cp $SNAPCRAFT_PART_INSTALL/bin/pip* bin/
       pip download pip -d lib/python*/site-packages/virtualenv_support/
-  charm-version:
+  versions:
+    after: [charmstore-client, charm-tools]
     source: snap/workarounds/
     plugin: dump
     override-stage: |
-      snapcraftctl stage
-      ../parts/charm-tools/build/charmtools/git_version.py --build-charm-version
-    after: [charm-tools]
+      charmtools=../parts/charm-tools/src
+      charmstore=../parts/charmstore-client/src
+      $charmtools/charmtools/git_version.py $charmtools --format=json > charm-tools-version
+      $charmtools/charmtools/git_version.py $charmstore --format=json > charmstore-client-version
+    prime:
+      - charm-tools-version
+      - charmstore-client-version

--- a/snap/workarounds/charmstore-client-version
+++ b/snap/workarounds/charmstore-client-version
@@ -1,1 +1,0 @@
-{"snap": "", "git": "", "gitn": 0, "version": "2.3.0", "pre_release": false}

--- a/snap/workarounds/charmstore-client-version
+++ b/snap/workarounds/charmstore-client-version
@@ -1,1 +1,1 @@
-2.3.0
+{"snap": "", "git": "", "gitn": 0, "version": "2.3.0", "pre_release": false}


### PR DESCRIPTION
Because the charmstore-client repo doesn't have official releases often, the base version number is often not indicative of what is actually included.  This extends the existing git_version support to include the charmstore-client component as well.

Example output:

```
charmstore-client 2.3.0+git-11-g5ea61cd
charm-tools 2.2.5+snap-x1+git-3-g32b98a2
```