### PR TITLE
made charm-build has the ability to parse devices metadata

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -24,7 +24,7 @@ Next the build needs to be run::
 make
 ```
 
-Tests can be run my make or as a script (which allows for command-line options
+Tests can be run by make or as a script (which allows for command-line options
 to be passed).
 
 ```bash

--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -720,11 +720,11 @@ def validate_devices(charm, linter):
         messages will be written
 
     """
-    devices = charm.get('devices', None)
-    if devices is None:
+    devices = charm.get('devices', {})
+    if devices == {}:
         return
 
-    if not isinstance(devices, dict) or not devices:
+    if not isinstance(devices, dict):
         linter.err('devices: must be a dictionary of device definitions')
         return
 

--- a/tests/test_charm_proof.py
+++ b/tests/test_charm_proof.py
@@ -555,11 +555,11 @@ class DevicesValidationTest(TestCase):
         validate_devices(charm, linter)
         self.assertFalse(linter.err.called)
 
-    def test_devices_with_empty_config(self):
+    def test_devices_with_invalid_config(self):
         """Charm has empty devices configuration."""
         linter = Mock()
         charm = {
-            'devices': {}
+            'devices': 'invalid devices config'
         }
         validate_devices(charm, linter)
         self.assertEqual(linter.err.call_count, 1)


### PR DESCRIPTION
Description of change
made `charm-build` has the ability to parse `devices` metadata.
