### PR TITLE
Work around "out of date" error on LP builders

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,7 @@ parts:
   versions:
     after: [charmstore-client, charm-tools]
     source: snap/
+    source-type: git  # see https://bugs.launchpad.net/snapcraft/+bug/1791871
     plugin: dump
     override-stage: |
       charmtools=../parts/charm-tools/src


### PR DESCRIPTION
It seems that snapcraft 2.43 introduced an issue with `snap pull $part; snapcraft` causing an "out of date" error.  This is supposed to work around that.

See https://bugs.launchpad.net/snapcraft/+bug/1791871