### PR TITLE
Fix issue 442 - raise error if proof fails

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -861,6 +861,10 @@ def main(args=None):
                 llog.warn(line)
             elif line[0] == "E":
                 llog.error(line)
+
+        if exit_code > 0:
+            raise SystemExit(exit_code)
+
     except (BuildError, FetchError) as e:
         if e.args:
             log.error(*e.args)


### PR DESCRIPTION
This patch address issue #442, where a failed charm proof does not
return a non-error exit code for `charm build`.

Description of change

## Checklist

 - [x] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [ ] Does your code pass `make test`?
