### PR TITLE
Remove source: key from snap to fix build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,6 @@ parts:
       pip download pip -d lib/python*/site-packages/virtualenv_support/
   versions:
     after: [charmstore-client, charm-tools]
-    source: snap/
     source-type: git  # see https://bugs.launchpad.net/snapcraft/+bug/1791871
     plugin: dump
     override-stage: |


### PR DESCRIPTION
Not sure why this worked previously and no longer does, but without it the paths are still correct and it fixes the error.