### PR TITLE
Fix version causing build signature issues

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -955,6 +955,7 @@ class VersionTactic(Tactic):
         super(VersionTactic, self).__init__(
             charm / self.FILENAME, target, layer, next_config)
         self.charm = charm
+        self.wrote_sha = False
 
     def read(self):
         if self.entity.isfile():
@@ -973,7 +974,7 @@ class VersionTactic(Tactic):
 
     def _try_to_get_current_sha(self):
         cmds = (
-            ('git', 'describe', '--dirty'),
+            ('git', 'describe', '--dirty', '--always'),
             ('bzr', 'version-info'),
             ('hg', 'id', '-n'),
         )
@@ -995,21 +996,27 @@ class VersionTactic(Tactic):
         if new_sha and old_sha and new_sha != old_sha:
             log.warn(
                 ("version {} is out of update, new sha {} "
-                "will be used!").format(old_sha, new_sha))
+                 "will be used!").format(old_sha, new_sha))
         sha = new_sha or old_sha
         if sha:
             self.target_file.write_bytes(sha.encode())
+            self.wrote_sha = True
+        else:
+            self.wrote_sha = False
 
     def sign(self):
         """return sign in the form {relpath: (origin layer, SHA256)}
         """
-        return {
-            self.target_file.relpath(self.target.directory): (
-                self.layer.url,
-                self.kind,
-                utils.sign(self.target_file)
-            )
-        }
+        if self.wrote_sha:
+            return {
+                self.target_file.relpath(self.target.directory): (
+                    self.layer.url,
+                    "dynamic",
+                    utils.sign(self.target_file)
+                )
+            }
+        else:
+            return {}
 
     def __str__(self):
         return "Ensuring {}".format(self.entity)

--- a/helpers/snap-wrappers/charm
+++ b/helpers/snap-wrappers/charm
@@ -25,5 +25,6 @@ warn "from strict to classic. For security reasons, updates will be blocked unti
 warn "you manually refresh to authorize the new confinement by doing the following:"
 warn ""
 warn "    sudo snap refresh charm --classic"
+warn ""
 
 exec "$SNAP/bin/charm" "$@"


### PR DESCRIPTION
The version file was getting added to the manifest even if it wasn't created, causing a modification error stating that it was removed after the last build.
    
It was also failing if the charm was a git repo that didn't have annotated tags instead of just using the sha.