### PR TITLE
Remove plugs for classic snap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ otherstuf==1.1.0
 path.py>=10.5
 pathspec==0.3.4
 pip>=10.0.0
-requests==2.9.1
+requests<=2.19.1
 responses==0.3.0
 ruamel.yaml==0.10.23
 virtualenv>=1.11.4

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'cheetah3>=3.0.0',
         'pyyaml==3.11',
         'paramiko<2.0.0',
-        'requests<=2.9.1',
+        'requests<=2.19.1',
         'libcharmstore',
         'blessings<=1.6',
         'ruamel.yaml<=0.10.23',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,11 +8,6 @@ grade: stable
 apps:
   charm:
     command: bin/wrappers/charm
-    plugs:
-      - network
-      - browser-support
-      - home
-      - removable-media
 parts:
   go:
     source-tag: go1.10.3


### PR DESCRIPTION
Snap build failed with: Error:confinement 'classic' not allowed with plugs/slots.