### PR TITLE
Non interface relation hooks

### DIFF
--- a/tests/trusty/b/metadata.yaml
+++ b/tests/trusty/b/metadata.yaml
@@ -8,4 +8,6 @@ categories:
 requires:
   mysql:
     interface: mysql
-
+provides:
+  unused:
+    interface: unused


### PR DESCRIPTION
Create relation hooks for all relations in metadata.yaml

Charms using relations without an external interface layer
now get relation hooks generated for them in the expected way,
and no longer need to maintain the hook stubs themselves.

Addresses #401 

My main use case for this are peer relations, of which there will only be a single implementation. It makes sense to development in the main charm's tree, but the hooks/*-relation-* files need to be manually maintained.

A number of tests needed mocks added, as they relied on plan_interfaces short circuiting when there were no interface: layers declared and skipping some sanity checks, and they had already mocked plan_hooks which durplicated those checks.