### PR TITLE
Fix interface layers linting ignored files

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -296,7 +296,12 @@ class InterfaceCopy(Tactic):
                       self.role)
             return False
         valid = True
-        for entry in self.interface.directory.walkfiles():
+        ignorer = utils.ignore_matcher(self.config.ignores +
+                                       self.interface.config.ignores)
+        for entry, _ in utils.walk(self.interface.directory,
+                                   lambda x: True,
+                                   matcher=ignorer,
+                                   kind="files"):
             if entry.splitext()[1] != ".py":
                 continue
             relpath = entry.relpath(self._target.directory)


### PR DESCRIPTION
This came up with the switch to classic confinement due to `.tox` directories getting picked up even though they were part of the ignore list.