### PR TITLE
Fix version in setup.py during install

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -67,12 +67,10 @@ charm version --format=long
 
 PyPI should be kept up to date with full releases, but the authoritative source
 is always the snap.  Note: for the version to work on PyPI, it needs to be cached
-in the `charmtools/VERSION` file, in JSON format.  This is not checked into git,
-and should be regenerated just prior to release.  Thus, to release to PyPI, you
-should do the following:
+in the `charmtools/VERSION` file, in JSON format.  This is updated automatically
+by `setup.py`, so to release to PyPI, you should just do the following:
 
 ```bash
-./charmtools/git_version.py --format=json > charmtools/VERSION
 python setup.py sdist upload
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,27 @@
 import os
 import subprocess
 import sys
+import json
 from setuptools import setup, find_packages
 
 
-version_script = os.path.join(os.path.dirname(__file__), 'charmtools', 'git_version.py')
-version = subprocess.check_output([sys.executable, version_script, '--format=short']).strip()
+curdir = os.path.dirname(__file__)
+version_cache = os.path.join(curdir, 'charmtools', 'VERSION')
+version_script = os.path.join(curdir, 'charmtools', 'git_version.py')
+version_raw = subprocess.check_output([sys.executable, version_script,
+                                       '--format=json']).strip()
 if sys.version_info >= (3, 0):
-    version = version.decode('UTF-8')
+    version_raw = version_raw.decode('UTF-8')
+version = json.loads(version_raw)['version']
+if version == 'unknown':
+    # during install; use cached VERSION
+    with open(version_cache, 'r') as fh:
+        version_raw = fh.read()
+    version = json.loads(version_raw)['version']
+else:
+    # during build; update cached VERSION
+    with open(version_cache, 'w') as fh:
+        fh.write(version_raw)
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as fh:
     readme = fh.read()


### PR DESCRIPTION
During install, `setup.py` is called again and tries to pull the version info from git rather than using the prepared cached `VERSION` file.

Fixes #457