### PR TITLE
Add support for local layer-index

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -787,7 +787,9 @@ def main(args=None):
     parser.add_argument('-s', '--series', default=None)
     parser.add_argument('--hide-metrics', dest="hide_metrics",
                         default=False, action="store_true")
-    parser.add_argument('--interface-service',
+    parser.add_argument('--interface-service', dest='layer_index',
+                        help="Deprecated: use --layer-index")
+    parser.add_argument('--layer-index',
                         default="https://juju.github.io/layer-index/")
     parser.add_argument('--no-local-layers', action="store_true",
                         help="Don't use local layers when building. "
@@ -814,8 +816,8 @@ def main(args=None):
         build.log_level = logging.DEBUG
 
     # Monkey patch in the domain for the interface webservice
-    InterfaceFetcher.INTERFACE_DOMAIN = build.interface_service
-    LayerFetcher.INTERFACE_DOMAIN = build.interface_service
+    InterfaceFetcher.INTERFACE_DOMAIN = build.layer_index
+    LayerFetcher.INTERFACE_DOMAIN = build.layer_index
 
     InterfaceFetcher.NO_LOCAL_LAYERS = build.no_local_layers
 

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -70,7 +70,7 @@ class InterfaceFetcher(fetchers.LocalFetcher):
                     choice_path = path(uri[7:])
                     if not choice_path.exists():
                         continue
-                    result = json.loads(path.text())
+                    result = json.loads(choice_path.text())
                     if not result.get('repo'):
                         continue
                     log.debug('Found repo: {}'.format(result['repo']))

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -1,4 +1,5 @@
 import os
+import json
 import logging
 
 import requests
@@ -26,6 +27,7 @@ class RepoFetcher(fetchers.LocalFetcher):
             if p.exists():
                 return dict(path=p)
         return {}
+
 
 fetchers.FETCHERS.insert(0, RepoFetcher)
 
@@ -64,9 +66,18 @@ class InterfaceFetcher(fetchers.LocalFetcher):
                 uri = "%s%s/%s.json" % (
                     cls.INTERFACE_DOMAIN, cls.ENDPOINT, choice)
                 log.debug('Checking layer index: {}'.format(uri))
+                if uri.startswith('file://'):
+                    choice_path = path(uri[7:])
+                    if not choice_path.exists():
+                        continue
+                    result = json.loads(path.text())
+                    if not result.get('repo'):
+                        continue
+                    log.debug('Found repo: {}'.format(result['repo']))
+                    return result
                 try:
                     result = requests.get(uri)
-                except:
+                except Exception:
                     result = None
                 if result and result.ok:
                     result = result.json()
@@ -118,6 +129,7 @@ class InterfaceFetcher(fetchers.LocalFetcher):
                 path.rename(res, target)
             return target
 
+
 fetchers.FETCHERS.insert(0, InterfaceFetcher)
 
 
@@ -127,5 +139,6 @@ class LayerFetcher(InterfaceFetcher):
     ENVIRON = "LAYER_PATH"
     OPTIONAL_PREFIX = "juju-layer-"
     ENDPOINT = "layers"
+
 
 fetchers.FETCHERS.insert(0, LayerFetcher)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,11 +51,14 @@ parts:
   versions:
     after: [charmstore-client, charm-tools]
     plugin: dump
-    override-stage: |
-      charmtools=../parts/charm-tools/src
-      charmstore=../parts/charmstore-client/src
-      $charmtools/charmtools/git_version.py $charmtools --format=json > charm-tools-version
-      $charmtools/charmtools/git_version.py $charmstore --format=json > charmstore-client-version
+    build: |
+      charmtools=../../charm-tools/src
+      charmstore=../../charmstore-client/src
+      $charmtools/charmtools/git_version.py $charmtools --format=json > $SNAPCRAFT_PART_INSTALL/charm-tools-version
+      $charmtools/charmtools/git_version.py $charmstore --format=json > $SNAPCRAFT_PART_INSTALL/charmstore-client-version
+    stage:
+      - charm-tools-version
+      - charmstore-client-version
     prime:
       - charm-tools-version
       - charmstore-client-version


### PR DESCRIPTION
The requests library doesn't support `file://` URLs, so we have to handle them specially.  This allows for a copy of the layer-index repo to be cloned locally and used instead.

Also rename `--interface-service` to `--layer-index`, partially addressing #438.