### PR TITLE
Add revision info to build manifest

### DIFF
--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -119,6 +119,9 @@ class InterfaceFetcher(fetchers.LocalFetcher):
         elif hasattr(self, "repo"):
             f, target = self._get_repo_fetcher_and_target(self.repo, dir_)
             res = f.fetch(dir_)
+            # make sure we save the revision of the actual repo, before we
+            # start traversing subdirectories and moving contents around
+            self.revision = self.get_revision(res)
             if res != target:
                 res = path(res)
                 if hasattr(self, 'subdir'):

--- a/charmtools/build/inspector.py
+++ b/charmtools/build/inspector.py
@@ -49,6 +49,7 @@ def inspect(charm, force_styling=False):
 
     # ordered list of layers used for legend
     layers = list(manifest['layers'])
+    layers_index = {layer['url']: i for i, layer in enumerate(layers)}
 
     def get_depth(e):
         rel = e.relpath(charm)
@@ -68,7 +69,7 @@ def inspect(charm, force_styling=False):
         color = tw.term.normal
         if rel in manifest['signatures']:
             layer = manifest['signatures'][rel][0]
-            layer_key = layers.index(layer)
+            layer_key = layers_index[layer]
             color = getattr(tw, theme.get(layer_key, "normal"))
         else:
             if entry.isdir():
@@ -79,7 +80,7 @@ def inspect(charm, force_styling=False):
     for layer in layers:
         tw.write("# {color}{layer}{t.normal}\n",
                  color=getattr(tw, theme.get(
-                     layers.index(layer), "normal")),
+                     layers_index[layer], "normal")),
                  layer=layer)
     tw.write("\n")
     tw.write("{t.blue}{target}{t.normal}\n", target=charm)

--- a/charmtools/fetchers.py
+++ b/charmtools/fetchers.py
@@ -110,14 +110,18 @@ class Fetcher(object):
         dirlist = os.listdir(dir_)
         if '.bzr' in dirlist:
             rev_info = check_output('bzr revision-info', cwd=dir_)
-            return rev_info.split()[1]
+            return rev_info.decode('utf8').strip().split()[1]
         elif '.git' in dirlist:
-            return check_output('git rev-parse HEAD', cwd=dir_)
+            rev_info = check_output('git rev-parse HEAD', cwd=dir_)
+            return rev_info.decode('utf8').strip()
         elif '.hg' in dirlist:
-            return check_output(
+            rev_info = check_output(
                 "hg log -l 1 --template '{node}\n' -r .", cwd=dir_)
-        else:
+            return rev_info.decode('utf8').strip()
+        elif hasattr(self, 'revision'):
             return self.revision
+        else:
+            return None
 
 
 class BzrFetcher(Fetcher):

--- a/charmtools/fetchers.py
+++ b/charmtools/fetchers.py
@@ -122,8 +122,7 @@ class Fetcher(object):
                     return rev_info.decode('utf8').strip()
             except FetchError:
                 continue
-        else:
-            return None
+        return None
 
 
 class BzrFetcher(Fetcher):


### PR DESCRIPTION
This allows tracking of exactly what a given charm was built with.
The build manifest is now (as of the latest charm snap release) uploaded to the store.

This doesn't provide any way of using this info to manage a rebuild, but it can at least be done manually via local checkouts of the layers, if needed.

Fixes #403