### PR TITLE
Restore historical behavior for --output-dir

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Installation
 
 To run the latest stable release, use::
 
-    sudo snap install charm
+    sudo snap install charm --classic
 
 You'll also almost certainly want to install Juju as well::
 

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -656,14 +656,15 @@ class Builder(object):
     def normalize_build_dir(self):
         charm_build_dir = os.environ.get('CHARM_BUILD_DIR')
         juju_repo_dir = os.environ.get('JUJU_REPOSITORY')
+        series = self.series or 'builds'
         if not self.build_dir:
+            if self.output_dir:
+                self.build_dir = self.output_dir / series
             if charm_build_dir:
                 self.build_dir = path(charm_build_dir)
             elif juju_repo_dir:
-                series = self.series or 'builds'
                 self.build_dir = path(juju_repo_dir) / series
             else:
-                series = self.series or 'builds'
                 log.warn('Build dir not specified via command-line or '
                          'environment; defaulting to /tmp/charm-builds')
                 self.build_dir = path('/tmp/charm-builds')
@@ -851,7 +852,7 @@ def main(args=None):
         formatter_class=argparse.RawDescriptionHelpFormatter,)
     parser.add_argument('-l', '--log-level', default=logging.INFO)
     parser.add_argument('-f', '--force', action="store_true")
-    parser.add_argument('-o', '--output-dir', type=path, dest='build_dir',
+    parser.add_argument('-o', '--output-dir', type=path,
                         help='Alias for --build-dir')
     parser.add_argument('-d', '--build-dir', type=path,
                         help='Directory under which to place built charms; '

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -49,11 +49,13 @@ class LayerFetcher(fetchers.LocalFetcher):
 
             if not cls.NO_LOCAL_LAYERS:
                 prefixed_name = '{}-{}'.format(cls.NAMESPACE, name)
-                search_path = [os.environ.get("JUJU_REPOSITORY", ".")]
+                search_path = []
                 if cls.ENVIRON in os.environ:
                     search_path.append(os.environ[cls.ENVIRON])
                 elif cls.OLD_ENVIRON in os.environ:
                     search_path.append(os.environ[cls.OLD_ENVIRON])
+                else:
+                    search_path.append(os.environ.get("JUJU_REPOSITORY", "."))
                 for part in search_path:
                     basepath = path(part)
                     for dirname in (name, prefixed_name):


### PR DESCRIPTION
Previous to #478, the behavior of `--output-dir` matched that of `$JUJU_REPOSITORY` in that it specified a directory which would have a `builds` or `{series}` directory created under it, which would then have the final charm output dir created under that.  This got changed and broke the charm builds for OpenStack, so this restores the previous behavior of `--output-dir` while retaining the new semantics for `--build-dir`.
