### PR TITLE
Fix typo to make the argument alias keep working

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -660,7 +660,7 @@ class Builder(object):
         if not self.build_dir:
             if self.output_dir:
                 self.build_dir = self.output_dir / series
-            if charm_build_dir:
+            elif charm_build_dir:
                 self.build_dir = path(charm_build_dir)
             elif juju_repo_dir:
                 self.build_dir = path(juju_repo_dir) / series


### PR DESCRIPTION

This commit fix the typo of the previous commit (5807aa1d) so we could
retain the alias of `--build-dir` when using `--output-dir`.

## Checklist

 - [ ] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
    - The link does not work anymore. Both of the links are empty as well https://github.com/juju-solutions/hacking.juju.solutions and https://github.com/juju-solutions/hacking-guide
 - [X] Are all your commits [logically] grouped and squashed appropriately?
 - [X] Does this patch have code coverage?
 - [X] Does your code pass `make test`?
