### PR TITLE
Use shutil.copytree instead of path.rename

### DIFF
--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+import shutil
 
 import requests
 from charmtools import fetchers
@@ -131,9 +132,7 @@ class LayerFetcher(fetchers.LocalFetcher):
                 if hasattr(self, 'subdir'):
                     res = res / self.subdir
                 target.rmtree_p()
-                # call this way instead of `res.rename(target)`
-                # to make unit test easier
-                path.rename(res, target)
+                shutil.copytree(res, target)
             return target
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -572,9 +572,9 @@ class TestFetchers(unittest.TestCase):
     @mock.patch('tempfile.mkdtemp', mock.Mock(return_value='/tmp/src'))
     @mock.patch('charmtools.fetchers.git')
     @mock.patch('charmtools.build.fetchers.path.rmtree_p', mock.Mock())
-    @mock.patch('charmtools.build.fetchers.path.rename')
+    @mock.patch('charmtools.build.fetchers.shutil.copytree')
     @mock.patch('charmtools.build.fetchers.requests')
-    def test_subdir(self, requests, rename, git):
+    def test_subdir(self, requests, copytree, git):
         requests.get.return_value.ok = True
         requests.get.return_value.json.return_value = {
             'repo': 'https://github.com/juju-solutions/mock-repo',
@@ -585,8 +585,8 @@ class TestFetchers(unittest.TestCase):
         assert fetcher.subdir == 'layers/test'
         target = fetcher.fetch('/tmp/dst')
         self.assertEqual(target, '/tmp/dst/test')
-        rename.assert_called_once_with(path('/tmp/src/layers/test'),
-                                       path('/tmp/dst/test'))
+        copytree.assert_called_once_with(path('/tmp/src/layers/test'),
+                                         path('/tmp/dst/test'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In https://review.openstack.org/#/c/635686/ I got:

```
OSError: [Errno 39] Directory not empty
```

I'm not sure if that was a spurious error because we haven't hit it before, but `shutil.copytree` is better suited for this anyway.