### PR TITLE
Allow `build` folders in the charm

### DIFF
--- a/charmtools/build/config.py
+++ b/charmtools/build/config.py
@@ -13,7 +13,6 @@ DEFAULT_IGNORES = [
     "*.pyc",
     "*~",
     ".tox",
-    "build",
 ]
 
 


### PR DESCRIPTION
# Description of change
By default, the `charm build` command excludes any file or folder with
the name `build`. It might be necessary to have such folder's name in the
charm.
It fixes #485 

## Checklist

 - [ ] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
Dead link
 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
