### PR TITLE
Fix and improve charm-layers

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -651,7 +651,9 @@ class Builder(object):
     def inspect(self):
         self.charm = path(self.charm).abspath()
         self._check_path(self.charm)
-        inspector.inspect(self.charm, force_styling=self.force_color)
+        inspector.inspect(self.charm,
+                          force_styling=self.force_color,
+                          annotate=self.annotate)
 
     def normalize_build_dir(self):
         charm_build_dir = os.environ.get('CHARM_BUILD_DIR')
@@ -795,6 +797,11 @@ def inspect(args=None):
                         dest='force_color', help="Alias of --force-color")
     parser.add_argument('-c', '--force-color', action="store_true",
                         help="Force raw output (color)")
+    parser.add_argument('-a', '--annotate', action="store_true",
+                        help="Annotate each file with the layer name, "
+                             "rather than just using colors "
+                             "(this is enabled automatically enabled if "
+                             "colors are unavailable)")
     parser.add_argument('-l', '--log-level', default=logging.INFO)
     parser.add_argument('charm', nargs="?", default=".", type=path)
     utils.add_plugin_description(parser)

--- a/charmtools/build/inspector.py
+++ b/charmtools/build/inspector.py
@@ -6,18 +6,18 @@ from charmtools import utils
 
 theme = {
     -1: "bright_black",
-    0: "white",
+    0: "normal",
     1: "green",
     2: "cyan",
     3: "magenta",
     4: "yellow",
     5: "red",
-    6: "bright_white",
-    7: "bright_green",
-    8: "bright_cyan",
-    9: "bright_magenta",
-    10: "bright_yellow",
-    11: "bright_red",
+    6: "bold",
+    7: "bright_magenta",
+    8: "bright_red",
+    9: "bright_cyan",
+    10: "bright_green",
+    11: "bright_yellow",
 }
 
 

--- a/charmtools/build/inspector.py
+++ b/charmtools/build/inspector.py
@@ -5,12 +5,19 @@ from charmtools.build import config
 from charmtools import utils
 
 theme = {
-    0: "normal",
+    -1: "bright_black",
+    0: "white",
     1: "green",
     2: "cyan",
     3: "magenta",
     4: "yellow",
     5: "red",
+    6: "bright_white",
+    7: "bright_green",
+    8: "bright_cyan",
+    9: "bright_magenta",
+    10: "bright_yellow",
+    11: "bright_red",
 }
 
 
@@ -37,7 +44,7 @@ def get_prefix(walk, cur, depth, next_depth):
     return "{}{}".format("".join(guide), prefix)
 
 
-def inspect(charm, force_styling=False):
+def inspect(charm, force_styling=False, annotate=False):
     tw = utils.TermWriter(force_styling=force_styling)
     manp = charm / ".build.manifest"
     comp = charm / "layer.yaml"
@@ -48,8 +55,10 @@ def inspect(charm, force_styling=False):
     a, c, d = utils.delta_signatures(manp)
 
     # ordered list of layers used for legend
-    layers = list(manifest['layers'])
-    layers_index = {layer['url']: i for i, layer in enumerate(layers)}
+    layers = [layer['url'] for layer in manifest['layers']]
+    layers.reverse()
+    while layers[0].startswith('interface:'):
+        layers.append(layers.pop(0))
 
     def get_depth(e):
         rel = e.relpath(charm)
@@ -69,7 +78,12 @@ def inspect(charm, force_styling=False):
         color = tw.term.normal
         if rel in manifest['signatures']:
             layer = manifest['signatures'][rel][0]
-            layer_key = layers_index[layer]
+            if layer in layers:
+                layer_key = layers.index(layer)
+            else:
+                # handle special build created artifacts, which have
+                # a "layer name" of "build" (mostly the manifest itself)
+                layer_key = -1
             color = getattr(tw, theme.get(layer_key, "normal"))
         else:
             if entry.isdir():
@@ -77,11 +91,16 @@ def inspect(charm, force_styling=False):
         return color
 
     tw.write("Inspect %s\n" % composer["is"])
-    for layer in layers:
-        tw.write("# {color}{layer}{t.normal}\n",
-                 color=getattr(tw, theme.get(
-                     layers_index[layer], "normal")),
-                 layer=layer)
+    if tw.does_styling or force_styling:
+        tw.write("\n")
+        tw.write("Color key:\n")
+        for i, layer in enumerate(layers):
+            tw.write("# {color}{layer}{t.normal}\n",
+                     color=getattr(tw, theme.get(i, "normal")),
+                     layer=layer)
+    else:
+        # force annotations if we can't use color
+        annotate = True
     tw.write("\n")
     tw.write("{t.blue}{target}{t.normal}\n", target=charm)
 
@@ -94,9 +113,23 @@ def inspect(charm, force_styling=False):
         if not ignorer(rel):
             continue
 
+        if annotate and rel in manifest['signatures']:
+            layer_name = manifest['signatures'][rel][0]
+            if layer_name == 'build':
+                # handle special build created artifacts, which have
+                # a "layer name" of "build" (mostly the manifest itself)
+                annotation = ' ({}build artifact{})'.format(tw.bright_black,
+                                                            tw.normal)
+            else:
+                annotation = ' (from {}{}{})'.format(get_color(rel),
+                                                     layer_name,
+                                                     tw.normal)
+        else:
+            annotation = ''
         tw.write("{prefix}{layerColor}{entry} "
-                 "{t.bold}{suffix}{t.normal}\n",
+                 "{t.bold}{suffix}{t.normal}{annotation}\n",
                  prefix=get_prefix(walk, i, depth, ndepth),
                  layerColor=get_color(rel),
                  suffix=get_suffix(rel),
-                 entry=rel.name)
+                 entry=rel.name,
+                 annotation=annotation)


### PR DESCRIPTION
The `charm layers` command was broken with the addition of revisions to the manifest.  This fixes that, and also adds some additional functionality, such as the ability to annotate the source layer when colors aren't available, and a larger number of colors to choose from so that charms with many layers won't run out quite as soon.

![layer-inspect](https://user-images.githubusercontent.com/406082/53260976-e075e200-36a0-11e9-9cae-63898e044561.png)
