### PR TITLE
Ensure setuptools for charmstore-client build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,7 @@ parts:
     build-packages:
       - bzr
       - python-pip
+      - python-setuptools
     override-build: |
       snapcraftctl build
       pip install vergit


### PR DESCRIPTION
```
Building charmstore-client 
Collecting vergit
[11/Mar/2019:19:11:03 +0000] "CONNECT pypi.python.org:443 HTTP/1.0" 200 4784 "-" "-"
  Cache entry deserialization failed, entry ignored
  Cache entry deserialization failed, entry ignored
  Downloading https://files.pythonhosted.org/packages/d8/dc/2ef077a97a05633bbe7a46b9cb4b87fbf994a9aaa52b44a8f1086d20951f/vergit-1.0.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: No module named setuptools
```