### PR TITLE
Add support for layer-index to pull-source and multiple indexes

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -883,7 +883,12 @@ def main(args=None):
     parser.add_argument('--interface-service',
                         help="Deprecated: use --layer-index")
     parser.add_argument('--layer-index',
-                        default=LayerFetcher.LAYER_INDEX)
+                        help='URL of main index to use to look up layers '
+                             '(default: {})'.format(
+                                 LayerFetcher.LAYER_INDEXES[0]))
+    parser.add_argument('--fallback-layer-index',
+                        help='URL of index to use to look up layers '
+                             'not found in main layer index')
     parser.add_argument('--no-local-layers', action="store_true",
                         help="Don't use local layers when building. "
                         "Forces included layers to be downloaded "
@@ -897,6 +902,8 @@ def main(args=None):
                              "for the built wheelhouse")
     parser.add_argument('-v', '--verbose', action='store_true', default=False,
                         help="Increase output (same as -l DEBUG)")
+    parser.add_argument('--debug', action='store_true',
+                        help='Same as --log-level=DEBUG')
     parser.add_argument('-c', '--force-color', action="store_true",
                         help="Force raw output (color)")
     parser.add_argument('charm', nargs="?", default=".", type=path,
@@ -909,12 +916,15 @@ def main(args=None):
         parser.print_help()
         raise SystemExit(0)
 
-    if build.verbose:
+    if build.verbose or build.debug:
         build.log_level = logging.DEBUG
 
     # Monkey patch in the domain for the interface webservice
     layer_index = build.interface_service or build.layer_index
-    LayerFetcher.LAYER_INDEX = layer_index
+    if layer_index:
+        LayerFetcher.LAYER_INDEXES = [layer_index]
+    if build.fallback_layer_index:
+        LayerFetcher.LAYER_INDEXES.append(build.fallback_layer_index)
 
     LayerFetcher.NO_LOCAL_LAYERS = build.no_local_layers
 

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -883,10 +883,11 @@ def main(args=None):
     parser.add_argument('--interface-service',
                         help="Deprecated: use --layer-index")
     parser.add_argument('-i', '--layer-index',
-                        help='One or more index URLs use to look up layers, '
+                        help='One or more index URLs used to look up layers, '
                              'separated by commas. Can include the token '
                              'DEFAULT, which will be replaced by the default '
-                             'index{}: {}'.format(
+                             'index{} ({}).  E.g.: '
+                             'https://my-site.com/index/,DEFAULT'.format(
                                  'es' if len(LayerFetcher.LAYER_INDEXES) > 1
                                  else '',
                                  ','.join(LayerFetcher.LAYER_INDEXES)))

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -882,13 +882,14 @@ def main(args=None):
                         action="store_true")
     parser.add_argument('--interface-service',
                         help="Deprecated: use --layer-index")
-    parser.add_argument('--layer-index',
-                        help='URL of main index to use to look up layers '
-                             '(default: {})'.format(
-                                 LayerFetcher.LAYER_INDEXES[0]))
-    parser.add_argument('--fallback-layer-index',
-                        help='URL of index to use to look up layers '
-                             'not found in main layer index')
+    parser.add_argument('-i', '--layer-index',
+                        help='One or more index URLs use to look up layers, '
+                             'separated by commas. Can include the token '
+                             'DEFAULT, which will be replaced by the default '
+                             'index{}: {}'.format(
+                                 'es' if len(LayerFetcher.LAYER_INDEXES) > 1
+                                 else '',
+                                 ','.join(LayerFetcher.LAYER_INDEXES)))
     parser.add_argument('--no-local-layers', action="store_true",
                         help="Don't use local layers when building. "
                         "Forces included layers to be downloaded "
@@ -919,13 +920,8 @@ def main(args=None):
     if build.verbose or build.debug:
         build.log_level = logging.DEBUG
 
-    # Monkey patch in the domain for the interface webservice
-    layer_index = build.interface_service or build.layer_index
-    if layer_index:
-        LayerFetcher.LAYER_INDEXES = [layer_index]
-    if build.fallback_layer_index:
-        LayerFetcher.LAYER_INDEXES.append(build.fallback_layer_index)
-
+    LayerFetcher.set_layer_indexes(build.interface_service or
+                                   build.layer_index)
     LayerFetcher.NO_LOCAL_LAYERS = build.no_local_layers
 
     configLogging(build)

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -52,7 +52,7 @@ class LayerFetcher(fetchers.LocalFetcher):
         new_indexes = []
         for layer_index in layer_indexes:
             if layer_index == 'DEFAULT':
-                new_indexes.extend(cls.LAYER_INDEXES)
+                new_indexes.extend(cls._DEFAULT_LAYER_INDEXES)
             else:
                 new_indexes.append(layer_index)
         cls.LAYER_INDEXES = new_indexes

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -34,13 +34,32 @@ fetchers.FETCHERS.insert(0, RepoFetcher)
 
 
 class LayerFetcher(fetchers.LocalFetcher):
-    LAYER_INDEXES = ["https://juju.github.io/layer-index/"]
+    _DEFAULT_LAYER_INDEXES = ["https://juju.github.io/layer-index/"]
+    LAYER_INDEXES = _DEFAULT_LAYER_INDEXES
     NO_LOCAL_LAYERS = False
     NAMESPACE = "layer"
     ENVIRON = "CHARM_LAYERS_DIR"
     OLD_ENVIRON = "LAYER_PATH"
     OPTIONAL_PREFIX = "juju-layer-"
     ENDPOINT = "layers"
+
+    @classmethod
+    def set_layer_indexes(cls, layer_indexes):
+        if not layer_indexes:
+            return
+        if isinstance(layer_indexes, str):
+            layer_indexes = layer_indexes.split(',')
+        new_indexes = []
+        for layer_index in layer_indexes:
+            if layer_index == 'DEFAULT':
+                new_indexes.extend(cls.LAYER_INDEXES)
+            else:
+                new_indexes.append(layer_index)
+        cls.LAYER_INDEXES = new_indexes
+
+    @classmethod
+    def restore_layer_indexes(cls):
+        cls.LAYER_INDEXES = cls._DEFAULT_LAYER_INDEXES
 
     @classmethod
     def can_fetch(cls, url):

--- a/charmtools/fetchers.py
+++ b/charmtools/fetchers.py
@@ -349,7 +349,7 @@ def check_output(cmd, **kw):
         raise FetchError(msg)
     out, _ = p.communicate()
     if p.returncode != 0:
-        raise FetchError(out)
+        raise FetchError(out.decode('utf8'))
     log.debug('%s: %s', cmd, out)
     return out
 

--- a/charmtools/pullsource.py
+++ b/charmtools/pullsource.py
@@ -224,10 +224,10 @@ def setup_parser():
     )
     parser.add_argument(
         '-i', '--layer-index',
-        help='One or more index URLs use to look up layers, '
+        help='One or more index URLs used to look up layers, '
              'separated by commas. Can include the token '
              'DEFAULT, which will be replaced by the default '
-             'index{}: {}'.format(
+             'index{} ({}).  E.g.: https://my-site.com/index/,DEFAULT'.format(
                  'es' if len(fetchers.LayerFetcher.LAYER_INDEXES) > 1 else '',
                  ','.join(fetchers.LayerFetcher.LAYER_INDEXES)))
     parser.add_argument(

--- a/charmtools/pullsource.py
+++ b/charmtools/pullsource.py
@@ -255,7 +255,10 @@ def main():
         )
 
     fetchers.LayerFetcher.NO_LOCAL_LAYERS = True
-    fetchers.LayerFetcher.LAYER_INDEX = args.layer_index
+    if args.layer_index:
+        fetchers.LayerFetcher.LAYER_INDEXES = [args.layer_index]
+    if args.fallback_layer_index:
+        fetchers.LayerFetcher.LAYER_INDEXES.append(args.fallback_layer_index)
 
     return download_item(args)
 

--- a/charmtools/pullsource.py
+++ b/charmtools/pullsource.py
@@ -222,13 +222,14 @@ def setup_parser():
         'dir', nargs='?',
         help='Directory in which to place the downloaded source.',
     )
-    parser.add_argument('--layer-index',
-                        help='URL of main index to use to look up layers '
-                             '(default: {})'.format(
-                                 fetchers.LayerFetcher.LAYER_INDEXES[0]))
-    parser.add_argument('--fallback-layer-index',
-                        help='URL of index to use to look up layers '
-                             'not found in main layer index')
+    parser.add_argument(
+        '-i', '--layer-index',
+        help='One or more index URLs use to look up layers, '
+             'separated by commas. Can include the token '
+             'DEFAULT, which will be replaced by the default '
+             'index{}: {}'.format(
+                 'es' if len(fetchers.LayerFetcher.LAYER_INDEXES) > 1 else '',
+                 ','.join(fetchers.LayerFetcher.LAYER_INDEXES)))
     parser.add_argument(
         '-v', '--verbose',
         help='Show verbose output',
@@ -255,10 +256,7 @@ def main():
         )
 
     fetchers.LayerFetcher.NO_LOCAL_LAYERS = True
-    if args.layer_index:
-        fetchers.LayerFetcher.LAYER_INDEXES = [args.layer_index]
-    if args.fallback_layer_index:
-        fetchers.LayerFetcher.LAYER_INDEXES.append(args.fallback_layer_index)
+    fetchers.LayerFetcher.set_layer_indexes(args.layer_index)
 
     return download_item(args)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,19 +25,13 @@ class TestBuild(unittest.TestCase):
         os.environ.pop("JUJU_REPOSITORY", None)
         os.environ.pop("LAYER_PATH", None)
         os.environ.pop("INTERFACE_PATH", None)
-        layer_indexes = build.fetchers.LayerFetcher.LAYER_INDEXES
         self.p_post = mock.patch('requests.post')
         self.p_post.start()
-        # preserve the layer indexes between tests
-        self.p_layer_index = mock.patch('charmtools.build.fetchers.'
-                                        'LayerFetcher.LAYER_INDEXES',
-                                        layer_indexes)
-        self.p_layer_index.start()
 
     def tearDown(self):
         self.build_dir.rmtree_p()
         self.p_post.stop()
-        self.p_layer_index.stop()
+        build.fetchers.LayerFetcher.restore_layer_indexes()
 
     def test_default_no_hide_metrics(self):
         # In the absence of environment variables or command-line options,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,13 +25,13 @@ class TestBuild(unittest.TestCase):
         os.environ.pop("JUJU_REPOSITORY", None)
         os.environ.pop("LAYER_PATH", None)
         os.environ.pop("INTERFACE_PATH", None)
-        ifd = build.fetchers.LayerFetcher.LAYER_INDEX
+        layer_indexes = build.fetchers.LayerFetcher.LAYER_INDEXES
         self.p_post = mock.patch('requests.post')
         self.p_post.start()
-        # preserve the layer index between tests
+        # preserve the layer indexes between tests
         self.p_layer_index = mock.patch('charmtools.build.fetchers.'
-                                        'LayerFetcher.LAYER_INDEX',
-                                        ifd)
+                                        'LayerFetcher.LAYER_INDEXES',
+                                        layer_indexes)
         self.p_layer_index.start()
 
     def tearDown(self):


### PR DESCRIPTION
Adds support for `--layer-index` and `--fallback-layer-index` option to `charm pull-source` and the support for the latter to `charm build` as well.

Also fix an infinite recursion bug when dealing with local interface layers, due to an incorrect `super()` call.