### PR TITLE
Gracefully handle JSON decode errors from layer index

### DIFF
--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -95,7 +95,12 @@ class LayerFetcher(fetchers.LocalFetcher):
                         choice_path = path(uri[7:])
                         if not choice_path.exists():
                             continue
-                        result = json.loads(choice_path.text())
+                        try:
+                            result = json.loads(choice_path.text())
+                        except json.JSONDecodeError as e:
+                            log.error('Unable to parse index entry for {}: '
+                                      '{}'.format(url, e))
+                            continue
                         if not result.get('repo'):
                             continue
                         log.debug('Found repo: {}'.format(result['repo']))


### PR DESCRIPTION
If the layer index contains invalid JSON, it can cause the build to fail with a stack trace rather than a useful error message.