### PR TITLE
Fix installing from git without vergit installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,12 @@ except Exception:
     version = 'unknown'
 if version == 'unknown':
     # during install; use cached VERSION
-    with open(version_cache, 'r') as fh:
-        version_raw = fh.read()
-    version = json.loads(version_raw)['version']
+    try:
+        with open(version_cache, 'r') as fh:
+            version_raw = fh.read()
+        version = json.loads(version_raw)['version']
+    except Exception:
+        version = None
 else:
     # during build; update cached VERSION
     with open(version_cache, 'w') as fh:


### PR DESCRIPTION
Another corner case is installing directly from git but without vergit available, in which case there's no way to determine the version and we have to fall back to `None` (a.k.a. `0.0.0`).

Fixes #518