### PR TITLE
Update charm.1 manpage

### DIFF
--- a/charm.1
+++ b/charm.1
@@ -23,10 +23,10 @@ Written by Clint Byrum
 .\"
 .SH BUGS
 Report bugs at 
-.RB < https://launchpad.net/charm-tools/+bugs >
+.RB < https://github.com/juju/charm-tools/issues >
 .\"
 .SH COPYRIGHT
-Copyright \(co 2011 Canonical Ltd.
+Copyright \(co 2011-2019 Canonical Ltd.
 .PP
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
Moves the the bug reporting URL to match HACKING.md and
updates the copyright notice to be more recent than 2011.


