### PR TITLE
Upgrade to use py3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-sudo: false
 language: python
+dist: xenial
 python:
   - "2.7"
-  - "3.5"
+  - "3.7"
 install: pip install tox-travis
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-#envlist = py27, py32, py34, py35
-envlist = py27, py35
+envlist = py27, py37
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
Description of change

Relates to https://github.com/Homebrew/homebrew-core/pull/40496

Trying to upgrade to use Python 3.7 (which travis has the support with `dist: xenial`).
