### PR TITLE
Update pypi release target to work with newer tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,12 @@ deps = sphinx
        -e {toxinidir}
 
 [testenv:pypi]
+whitelist_externals =
+    /bin/rm
 deps =
     -r{toxinidir}/requirements.txt
     twine
 commands =
-    rm dist/*
+    rm -rf dist
     python setup.py sdist
     twine upload dist/*


### PR DESCRIPTION
Newer versions of tox restrict access to commands unless you explicitly whitelist or install them.