### PR TITLE
requirements.txt: update version limit for requests (#535)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ otherstuf==1.1.0
 path.py>=10.5
 pathspec==0.3.4
 pip>=10.0.0
-requests<=2.20.1
+requests>=2.0.0,<3.0.0
 responses==0.3.0
 ruamel.yaml<0.16.0
 virtualenv>=1.11.4


### PR DESCRIPTION
As a common used python utils, limit `requests` to old version will
conflict with plenty of other packages.
For example, it breaks `tox -e pep8` test in `charm-keystone`,
as reported in #535 and https://bugs.launchpad.net/charm-keystone/+bug/1836119

Adjust version limit to 2.0.0 <= version < 3.0.0

Closes #535 

## Checklist

 - [N] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions) --> URL is dead
 - [Y] Are all your commits [logically] grouped and squashed appropriately?
 - [Y] Does this patch have code coverage?
 - [Y] Does your code pass `make test`?
