### PR TITLE
Remove bad URL from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,6 @@ Description of change
 
 ## Checklist
 
- - [ ] Have you followed [Juju Solutions hacking guide?](https://hacking.juju.solutions)
  - [ ] Are all your commits [logically] grouped and squashed appropriately?
  - [ ] Does this patch have code coverage?
  - [ ] Does your code pass `make test`?


### PR DESCRIPTION
The URL in the PR template never existed and shouldn't have been included.

Fixes #245