### PR TITLE
edge case for setting charm_ver

### DIFF
--- a/charmtools/version.py
+++ b/charmtools/version.py
@@ -48,6 +48,8 @@ def cached_charmstore_client_version():
             if v.is_installed:
                 charm_ver = v.version
                 break
+        else:
+            charm_ver = 'unavailable'
     except ImportError:
         charm_ver = 'unavailable'
     except:


### PR DESCRIPTION
There's an edge case that leads to `charm version` failing like this:

```bash
$ charm version
Traceback (most recent call last):
  File "/usr/local/bin/charm-version", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.5/dist-packages/charmtools/version.py", line 95, in main
    format_version(cached_charmstore_client_version(), args.format)))
  File "/usr/local/lib/python3.5/dist-packages/charmtools/version.py", line 56, in cached_charmstore_client_version
    return _add_snap_rev({'version': charm_ver})
UnboundLocalError: local variable 'charm_ver' referenced before assignment
```

It happens when `charm` is not installed via apt nor snap, but rather with `go get` as described in [the docs](https://github.com/juju/charmstore-client#charmstore-client). In this case, our apt cache will know about a `charm` package, but since the apt package isn't installed, we'll never set `charm_ver`.

Fixable with an `else` on that apt.cache `for` loop so we set a default `charm_ver` in this case.
