### PR TITLE
Cleanup cached layers / interfaces after build

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -647,6 +647,7 @@ class Builder(object):
         self.validate()
         self.find_or_create_target()
         self.generate()
+        self.cleanup()
 
     def inspect(self):
         self.charm = path(self.charm).abspath()
@@ -749,6 +750,11 @@ class Builder(object):
                     log.info(' {} {}'.format(sigil, filename))
         else:
             log.info('No new changes; no files were modified.')
+
+    def cleanup(self):
+        for cached_layer in self.cache_dir.glob('*/*'):
+            log.debug('Cleaning up {}'.format(cached_layer))
+            cached_layer.rmtree_p()
 
 
 def configLogging(build):

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -148,7 +148,7 @@ class LayerFetcher(fetchers.LocalFetcher):
             return super(LayerFetcher, self).fetch(dir_)
         elif hasattr(self, "repo"):
             f, target = self._get_repo_fetcher_and_target(self.repo, dir_)
-            res = f.fetch(dir_)
+            orig_res = res = f.fetch(dir_)
             # make sure we save the revision of the actual repo, before we
             # start traversing subdirectories and moving contents around
             self.revision = self.get_revision(res)
@@ -157,7 +157,10 @@ class LayerFetcher(fetchers.LocalFetcher):
                 if hasattr(self, 'subdir'):
                     res = res / self.subdir
                 target.rmtree_p()
+                log.debug('Copying {} to {}'.format(res, target))
                 shutil.copytree(res, target)
+                log.debug('Cleaning up {}'.format(orig_res))
+                path(orig_res).rmtree_p()  # cleanup from cache after copied
             return target
 
 

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -336,7 +336,9 @@ class InterfaceCopy(Tactic):
         log.debug("Copying Interface %s: %s",
                   self.interface.name, self.target)
         ignorer = utils.ignore_matcher(self.config.ignores +
-                                       self.interface.config.ignores)
+                                       self.interface.config.ignores +
+                                       self.config.excludes +
+                                       self.interface.config.excludes)
         for entity, _ in utils.walk(self.interface.directory,
                                     lambda x: True,
                                     matcher=ignorer,
@@ -373,7 +375,9 @@ class InterfaceCopy(Tactic):
             return False
         valid = True
         ignorer = utils.ignore_matcher(self.config.ignores +
-                                       self.interface.config.ignores)
+                                       self.interface.config.ignores +
+                                       self.config.excludes +
+                                       self.interface.config.excludes)
         for entry, _ in utils.walk(self.interface.directory,
                                    lambda x: True,
                                    matcher=ignorer,

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -456,18 +456,26 @@ REACTIVE_PATTERNS = [
 
 def delta_python(orig, dest, patterns=REACTIVE_PATTERNS, context=2):
     """Delta two python files looking for certain patterns"""
-    if isinstance(orig, path):
-        od = orig.text()
-    elif hasattr(orig, 'read'):
-        od = orig.read()
-    else:
-        raise TypeError("Expected path() or file(), got %s" % type(orig))
-    if isinstance(dest, path):
-        dd = dest.text()
-    elif hasattr(orig, 'read'):
-        dd = dest.read()
-    else:
-        raise TypeError("Expected path() or file(), got %s" % type(dest))
+    try:
+        if isinstance(orig, path):
+            od = orig.text()
+        elif hasattr(orig, 'read'):
+            od = orig.read()
+        else:
+            raise TypeError("Expected path() or file(), got %s" % type(orig))
+    except Exception:
+        log.error('Error reading {}'.format(orig))
+        raise
+    try:
+        if isinstance(dest, path):
+            dd = dest.text()
+        elif hasattr(orig, 'read'):
+            dd = dest.read()
+        else:
+            raise TypeError("Expected path() or file(), got %s" % type(dest))
+    except Exception:
+        log.error('Error reading {}'.format(dest))
+        raise
 
     differ = diff_match_patch()
     linect = 0

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# clean up orphaned cache directories which take up unused space
+for user in /home/*; do
+    if [ -e $user/.cache/charm ]; then
+        rm -rf $user/.cache/charm/*
+    fi
+done

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,8 +1,4 @@
 #!/bin/bash
 
 # clean up orphaned cache directories which take up unused space
-for user in /home/*; do
-    if [ -e $user/.cache/charm ]; then
-        rm -rf $user/.cache/charm/*
-    fi
-done
+rm -rf /home/*/.cache/charm/*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
       vergit --format=json > $SNAPCRAFT_PART_INSTALL/charm-tools-version
       snapcraftctl set-version $(vergit)
       # ensure we don't accidentally pick up system py2
-      ln -s python3 $SNAPCRAFT_PART_INSTALL/usr/bin/python
+      ln -s python3 $SNAPCRAFT_PART_INSTALL/usr/bin/python || true
       # copy our wrappers into the right place; note: we cannot use organize,
       # because it will break things (see forum link below)
       cp -R helpers/snap-wrappers $SNAPCRAFT_PART_INSTALL/bin/wrappers


### PR DESCRIPTION
The build process currently leaves directories under `~/.cache/charm/{layer,interface}/` which over time can build up and waste space.

Fixes #539

Additionally:

  * Fix handling of excludes in interface layers. The `ignore` setting is honored by interface layers but actually uses the mechanic of `exclude`, while `exclude` itself is not honored. This adds support for `exclude` with the proper behavior and leaves `ignore` as-is for compatibility.

  * Improve error reporting during interface layer linting when a file fails to decode.

  * Fix a snapcraft error if python binary already exists.