### PR TITLE
fix charm build help message

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -856,7 +856,7 @@ def main(args=None):
                                  "interface layers"),
         ("CHARM_BUILD_DIR", "Build charms will be placed into "
                             "$CHARM_BUILD_DIR/{charm_name} "
-                            "(defaults to current directory)"),
+                            "(defaults to /tmp/charm-builds/)"),
         ("JUJU_REPOSITORY", "Deprecated: If CHARM_BUILD_DIR is not set but "
                             "this is, built charms will be placed into "
                             "$JUJU_REPOSITORY/builds/{charm_name}"),


### PR DESCRIPTION
`charm build --help`:

    Build charms will be placed into $CHARM_BUILD_DIR/{charm_name} (defaults to current directory)

This is not true, the real path in code is `/tmp/charm-builds/`

Signed-off-by: Joe Guo <guoqiao@gmail.com>

Description of change

## Checklist

 - [ ] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [ ] Does your code pass `make test`?
