### PR TITLE
Fix snap builds on other arches

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,11 +18,10 @@ parts:
     go-importpath: github.com/juju/charmstore-client
     build-packages:
       - bzr
-      - python-pip
-      - python-setuptools
+      - python3-pip
     override-build: |
       snapcraftctl build
-      pip install vergit
+      pip3 install vergit
       vergit --format=json > $SNAPCRAFT_PART_INSTALL/charmstore-client-version
   bhttp:
     plugin: godeps
@@ -41,8 +40,6 @@ parts:
       - git-core
       - libssl-dev
       - libffi-dev
-      - python3
-      - python3-setuptools
     override-build: |
       snapcraftctl build
       vergit --format=json > $SNAPCRAFT_PART_INSTALL/charm-tools-version


### PR DESCRIPTION
Snap builds for several arches have been failing for a long time due to the setuptools / pip `__legacy__` attribute issue.  This fixes that by removing unnecessary system packages during the build.

Fixes #521 

Tested with `snapcraft remote-build --arch armhf`