### PR TITLE
Fix maintainer validation not handling unicode

### DIFF
--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -332,7 +332,8 @@ class Charm(object):
             validate_payloads(charm, lint, proof_extensions.get('payloads'))
             validate_terms(charm, lint)
             validate_resources(charm, lint, proof_extensions.get('resources'))
-            validate_deployment(charm, lint, proof_extensions.get('deployment'))
+            validate_deployment(charm, lint,
+                                proof_extensions.get('deployment'))
 
             if not os.path.exists(os.path.join(charm_path, 'icon.svg')):
                 lint.info("No icon.svg file.")
@@ -978,11 +979,7 @@ def validate_maintainer(charm, linter):
 
     for maintainer in maintainers:
         (name, address) = email.utils.parseaddr(maintainer)
-        formatted = email.utils.formataddr((name, address))
-        lt = formatted.find('<')
-        gt = formatted.find('>')
-        if (formatted.replace('"', '') != maintainer or
-                lt < 0 or gt < 0 or gt < lt):
+        if not (name and address):
             linter.warn(
                 'Maintainer format should be "Name <Email>", '
                 'not "%s"' % maintainer)

--- a/tests/layers/tester/metadata.yaml
+++ b/tests/layers/tester/metadata.yaml
@@ -1,6 +1,6 @@
 name: tester
 summary: An imagined extension to the mysql charm
-maintainer: Tester <test@er.com>
+maintainer: Tésty Téstér <téstér@example.com>
 description: |
   MySQL is a fast, stable and true multi-user, multi-threaded SQL database
   server. SQL (Structured Query Language) is the most popular database query

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -144,7 +144,8 @@ class TestBuild(unittest.TestCase):
         # The maintainer, maintainers values should only be from the top layer.
         self.assertIn("maintainer", metadata_data)
         self.assertEqual(metadata_data['maintainer'],
-                         "Tésty Téstér <téstér@example.com>")
+                         b"T\xc3\xa9sty T\xc3\xa9st\xc3\xa9r "
+                         b"<t\xc3\xa9st\xc3\xa9r@example.com>".decode('utf8'))
         self.assertNotIn("maintainers", metadata_data)
         # The tags list must be de-duplicated.
         self.assertEqual(metadata_data['tags'], ["databases"])

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -143,7 +143,8 @@ class TestBuild(unittest.TestCase):
         self.assertIn("storage", metadata_data['provides'])
         # The maintainer, maintainers values should only be from the top layer.
         self.assertIn("maintainer", metadata_data)
-        self.assertEqual(metadata_data['maintainer'], "Tester <test@er.com>")
+        self.assertEqual(metadata_data['maintainer'],
+                         "Tésty Téstér <téstér@example.com>")
         self.assertNotIn("maintainers", metadata_data)
         # The tags list must be de-duplicated.
         self.assertEqual(metadata_data['tags'], ["databases"])
@@ -203,7 +204,7 @@ class TestBuild(unittest.TestCase):
         self.assertEquals(data["signatures"]['metadata.yaml'], [
             u'foo',
             "dynamic",
-            u'03fc06a5e698e624231b826f4c47a60d3251cbc968fc1183ada444ca09b29ea6'
+            u'12c1f6fc865da0660f6dc044cca03b0244e883d9a99fdbdfab6ef6fc2fed63b7'
             ])
 
         storage_attached = base / "hooks/data-storage-attached"


### PR DESCRIPTION
The maintainer email validation code used [`email.utils.parseaddr`](https://docs.python.org/3/library/email.utils.html#email.utils.parseaddr) but then second-guessed it by reformatting it and trying to do manual parsing, which failed with non-ASCII characters.

Fixes #531