### PR TITLE
Allow boolean config options to have null default

### DIFF
--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -68,7 +68,7 @@ KNOWN_OPTION_TYPES = {
     'boolean': bool,
 }
 
-ALLOW_NONE_DEFAULT = (six.string_types[0], int, float)
+ALLOW_NONE_DEFAULT = (six.string_types[0], int, float, bool)
 
 
 class RelationError(Exception):

--- a/tests/test_charm_proof.py
+++ b/tests/test_charm_proof.py
@@ -340,7 +340,7 @@ class TestCharmProof(TestCase):
         self.linter.check_config_file(self.charm_dir)
         self.assertEqual(1, len(self.linter.lint))
         expected = (
-            'W: config.yaml: option foo has no default value')
+            'I: config.yaml: option foo has no default value')
         self.assertEqual(expected, self.linter.lint[0])
 
     def test_yaml_with_python_objects(self):


### PR DESCRIPTION
It is occasionally useful to have an explicit null / None default value for boolean config options to detect the difference between the user explicitly wanting false or not. This changes the proof message to informational.