### PR TITLE
Fix 471

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ responses==0.3.0
 ruamel.yaml<0.16.0
 virtualenv>=1.11.4
 jsonschema==2.5.1
+keyring<21
 secretstorage<2.4
 six>=1.11.0
 dict2colander==0.2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,7 @@ parts:
       - git-core
       - libssl-dev
       - libffi-dev
+      - libpython3-dev
     override-build: |
       snapcraftctl build
       vergit --format=json > $SNAPCRAFT_PART_INSTALL/charm-tools-version
@@ -67,4 +68,4 @@ parts:
       # explicitly added to stage.  Also forcibly update the pip embedded in
       # virtualenv to get the lsb_release fix that was released with pip 10.
       cp $SNAPCRAFT_PART_INSTALL/bin/pip* bin/
-      pip download pip -d lib/python*/site-packages/virtualenv_support/
+      python3 -m pip download pip -d lib/python*/site-packages/virtualenv_support/


### PR DESCRIPTION
When using modules that need to compile C extensions will need the
development headers of Python.

Fixes #471

Description of change

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
