### PR TITLE
Add OpenStack templates to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ six>=1.11.0
 dict2colander==0.2
 setuptools>=40.8.0,<50.0.0
 vergit>=1.0.0,<2.0.0
+git+https://github.com/openstack-charmers/charm-templates-openstack.git#egg=charm_templates_openstack


### PR DESCRIPTION
This change supports use of the OpenStack charm create templates
as part of the charm snap.