### PR TITLE
Add vim *.swp files to DEFAULT_IGNORES

### DIFF
--- a/charmtools/build/config.py
+++ b/charmtools/build/config.py
@@ -13,6 +13,7 @@ DEFAULT_IGNORES = [
     "*.pyc",
     "*~",
     ".tox",
+    "*.swp",
 ]
 
 


### PR DESCRIPTION
This commit addresses the concerns raised in issue #421 with charm proof
failing on vim swap files when someone has a readme file open in an
editor while running charm build which then compiles and proofs the
README*.swp file which is not UTF-8 compliant.

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [] Does your code pass `make test`?
  - Having trouble with python dependencies for test.