### PR TITLE
Add workaround for user site package conflicts

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,7 @@ parts:
       - libpython3-dev
     override-build: |
       snapcraftctl build
+      sed -i "$SNAPCRAFT_PART_INSTALL/usr/lib/python3.6/site.py" -e 's/^ENABLE_USER_SITE = None$/ENABLE_USER_SITE = False/'
       vergit --format=json > $SNAPCRAFT_PART_INSTALL/charm-tools-version
       snapcraftctl set-version $(vergit)
       # ensure we don't accidentally pick up system py2


### PR DESCRIPTION
On environments with user site packages installed, they can be picked up by the Python bundled into the snap and cause version conflicts. This workaround [borrowed from snapcraft](https://github.com/snapcore/snapcraft/blob/bd5be51/tools/snapcraft-override-build.sh#L18) prevents this.

Fixes #559