### PR TITLE
Tweak Build Snap action

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -22,5 +22,5 @@ jobs:
       id: snapcraft
     - uses: actions/upload-artifact@v1
       with:
-        name: snap
+        name: charm.snap
         path: ${{ steps.snapcraft.outputs.snap }}


### PR DESCRIPTION
* Rename output artifact to `charm.snap`; this will download as `charm.snap.zip` which will need to be unzipped to get the actual snap
* Rename yaml file so we can add other actions in the future.