### PR TITLE
Default to charming category of the Juju Discourse

### DIFF
--- a/charmtools/templates/operator_python/template.py
+++ b/charmtools/templates/operator_python/template.py
@@ -56,7 +56,7 @@ class OperatorPythonCharmTemplate(CharmTemplate):
             },
             "bug_tracker": {
                 "prompt": "URL where bugs can be filed for this Charm:",
-                "default": "https://launchpad.net/amazing-charm",
+                "default": "https://discourse.juju.is/c/charming",
             }
         })
         return promptlist


### PR DESCRIPTION
Changes the default bug tracker URL to a location that actually exists.