### PR TITLE
Handle invalid config file more gracefully

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -524,12 +524,10 @@ class Builder(object):
         if self.hide_metrics:
             return
         conf_file = path('~/.config/charm-build.conf').expanduser()
-        conf = {}
-        if conf_file.exists():
-            try:
-                conf = yaml.safe_load(conf_file.text()) or {}
-            except yaml.error.YAMLError:
-                pass
+        try:
+            conf = yaml.safe_load(conf_file.text()) or {}
+        except (FileNotFoundError, yaml.error.YAMLError):
+            conf = {}
         if not conf.get('cid'):
             conf_file.parent.makedirs_p()
             conf['cid'] = str(uuid.uuid4())

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -524,13 +524,17 @@ class Builder(object):
         if self.hide_metrics:
             return
         conf_file = path('~/.config/charm-build.conf').expanduser()
+        conf = {}
         if conf_file.exists():
-            conf = yaml.safe_load(conf_file.text())
-            cid = conf['cid']
-        else:
+            try:
+                conf = yaml.safe_load(conf_file.text()) or {}
+            except yaml.error.YAMLError:
+                pass
+        if not conf.get('cid'):
             conf_file.parent.makedirs_p()
-            cid = str(uuid.uuid4())
-            conf_file.write_text(yaml.dump({'cid': cid}))
+            conf['cid'] = str(uuid.uuid4())
+            conf_file.write_text(yaml.safe_dump(conf))
+        cid = conf['cid']
         try:
             requests.post(self.METRICS_URL, timeout=10, data={
                 'tid': self.METRICS_ID,


### PR DESCRIPTION
Fixes spurious build errors like:

```python-traceback
Traceback (most recent call last):
  File "/snap/charm/461/bin/charm-build", line 11, in <module>
    load_entry_point('charm-tools==2.7.4', 'console_scripts', 'charm-build')()
  File "/snap/charm/461/lib/python3.6/site-packages/charmtools/build/builder.py", line 941, in main
    build()
  File "/snap/charm/461/lib/python3.6/site-packages/charmtools/build/builder.py", line 649, in __call__
    self.generate()
  File "/snap/charm/461/lib/python3.6/site-packages/charmtools/build/builder.py", line 592, in generate
    layers = self.fetch()
  File "/snap/charm/461/lib/python3.6/site-packages/charmtools/build/builder.py", line 272, in fetch
    self.post_metrics('charm', self.name, False)
  File "/snap/charm/461/lib/python3.6/site-packages/charmtools/build/builder.py", line 529, in post_metrics
    cid = conf['cid']
TypeError: 'NoneType' object is not subscriptable
```