### PR TITLE
Process wheelhouse.txt holistically rather than per-layer

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -914,7 +914,8 @@ def main(args=None):
                         help="Provide a wheelhouse.txt file with overrides "
                              "for the built wheelhouse")
     parser.add_argument('-W', '--wheelhouse-per-layer', action="store_true",
-                        help="Use old per-layer wheelhouse processing")
+                        help="Deprecated: Use original wheelhouse processing "
+                             "method (see PR juju/charm-tools#569)")
     parser.add_argument('-v', '--verbose', action='store_true', default=False,
                         help="Increase output (same as -l DEBUG)")
     parser.add_argument('--debug', action='store_true',

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -148,6 +148,7 @@ class Builder(object):
         self._top_layer = None
         self.hide_metrics = os.environ.get('CHARM_HIDE_METRICS', False)
         self.wheelhouse_overrides = None
+        self.wheelhouse_per_layer = False
         self._warned_home = False
 
     @property
@@ -904,11 +905,16 @@ def main(args=None):
                         "from the interface service.")
     parser.add_argument('-n', '--name',
                         help="Build a charm of 'name' from 'charm'")
-    parser.add_argument('-r', '--report', action="store_true",
+    parser.add_argument('-r', '--report', action="store_true", default=True,
                         help="Show post-build report of changes")
+    parser.add_argument('-R', '--no-report', action="store_false",
+                        dest='report', default=True,
+                        help="Don't show post-build report of changes")
     parser.add_argument('-w', '--wheelhouse-overrides', type=path,
                         help="Provide a wheelhouse.txt file with overrides "
                              "for the built wheelhouse")
+    parser.add_argument('-W', '--wheelhouse-per-layer', action="store_true",
+                        help="Use old per-layer wheelhouse processing")
     parser.add_argument('-v', '--verbose', action='store_true', default=False,
                         help="Increase output (same as -l DEBUG)")
     parser.add_argument('--debug', action='store_true',
@@ -931,6 +937,8 @@ def main(args=None):
     LayerFetcher.set_layer_indexes(build.interface_service or
                                    build.layer_index)
     LayerFetcher.NO_LOCAL_LAYERS = build.no_local_layers
+
+    WheelhouseTactic.per_layer = build.wheelhouse_per_layer
 
     configLogging(build)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -434,6 +434,7 @@ class TestBuild(unittest.TestCase):
         bu.hide_metrics = True
         bu.report = False
         bu.wheelhouse_overrides = self.dirname / 'wh-over.txt'
+        Process.return_value.return_value.exit_code = 0
 
         # remove the sign phase
         bu.PHASES = bu.PHASES[:-2]


### PR DESCRIPTION
Processing the wheelhouse.txt file from each layer in isolation means that pip can't resolve conflicts, duplicates, or dependency version pinning which spans across layers.  This can lead to duplicate versions of libraries being installed which violate constraints to avoid certain upstream bugs.

This came up in both of:

* https://bugs.launchpad.net/charm-flannel/+bug/1884598
* https://bugs.launchpad.net/charm-octavia/+bug/1884164

And in both cases trying to resolve it on a per-layer or per-charm basis results in a whack-a-mole process of catching all of the layers which indirectly reintroduce the unpinned version of a 
dependency pinned in a base layer.