### PR TITLE
Add --branch option to pull-source

### DIFF
--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -42,6 +42,8 @@ class LayerFetcher(fetchers.LocalFetcher):
     OLD_ENVIRON = "LAYER_PATH"
     OPTIONAL_PREFIX = "juju-layer-"
     ENDPOINT = "layers"
+    _DEFAULT_BRANCH = None
+    BRANCH = _DEFAULT_BRANCH
 
     @classmethod
     def set_layer_indexes(cls, layer_indexes):
@@ -60,6 +62,16 @@ class LayerFetcher(fetchers.LocalFetcher):
     @classmethod
     def restore_layer_indexes(cls):
         cls.LAYER_INDEXES = cls._DEFAULT_LAYER_INDEXES
+
+    @classmethod
+    def set_branch(cls, branch):
+        if not branch:
+            return
+        cls.BRANCH = branch
+
+    @classmethod
+    def restore_branch(cls):
+        cls.BRANCH = cls._DEFAULT_BRANCH
 
     @classmethod
     def can_fetch(cls, url):
@@ -145,9 +157,14 @@ class LayerFetcher(fetchers.LocalFetcher):
 
     def fetch(self, dir_):
         if hasattr(self, "path"):
+            log.debug('Using fetcher: {}'.format(super(LayerFetcher, self)))
             return super(LayerFetcher, self).fetch(dir_)
         elif hasattr(self, "repo"):
             f, target = self._get_repo_fetcher_and_target(self.repo, dir_)
+            log.debug('Using fetcher: {}'.format(f))
+            if self.BRANCH is not None:
+                log.debug('Adding branch: %s', self.BRANCH)
+                f.revision = self.BRANCH
             orig_res = res = f.fetch(dir_)
             # make sure we save the revision of the actual repo, before we
             # start traversing subdirectories and moving contents around

--- a/charmtools/pullsource.py
+++ b/charmtools/pullsource.py
@@ -223,6 +223,12 @@ def setup_parser():
         help='Directory in which to place the downloaded source.',
     )
     parser.add_argument(
+        '-b', '--branch',
+        help='Branch to check out after cloning the repo '
+             '(before copying any subdir). If not given, '
+             'the default branch of the repo will be used.'
+    )
+    parser.add_argument(
         '-i', '--layer-index',
         help='One or more index URLs used to look up layers, '
              'separated by commas. Can include the token '
@@ -257,6 +263,7 @@ def main():
 
     fetchers.LayerFetcher.NO_LOCAL_LAYERS = True
     fetchers.LayerFetcher.set_layer_indexes(args.layer_index)
+    fetchers.LayerFetcher.set_branch(args.branch)
 
     return download_item(args)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,9 @@ libcharmstore>=0.0.3
 cheetah3==3.0.0
 colander==1.7.0
 coverage
-flake8==1.6.2
 juju-deployer==0.4.3
 jujubundlelib>=0.5.6
 mock==1.3.0
-nose==1.3.7
 otherstuf==1.1.0
 path.py>=10.5
 pathspec==0.3.4

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skipsdist = true
 [testenv]
 install_command =  pip install {opts} {packages}
 passenv = TERM
-commands = pytest -s --tb native --disable-warnings --ignore=tests/layers {posargs:tests}
+commands = pytest -s --tb native --disable-warnings --ignore=tests/layers --cov=charmtools {posargs:tests}
 deps =
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py37
+envlist = py27, py3
 skipsdist = true
 
 [testenv]
 install_command =  pip install {opts} {packages}
 passenv = TERM
-commands = coverage erase
-           coverage run --include=charmtools/* -- {envbindir}/nosetests -s {posargs}
-           coverage report
+commands = pytest -s --tb native --disable-warnings --ignore=tests/layers {posargs:tests}
 deps =
+    pytest
+    pytest-cov
+    flake8
     -r{toxinidir}/requirements.txt
     -e {toxinidir}
     ipdb


### PR DESCRIPTION
Adds the ability to specify a branch to switch to when fetching the source of a charm or layer.  This is particularly useful for layer
entries which use the `subdir` field, since that can lose the SCM metadata and prevent post-pull switching.

Fixes #580
Fixes [lp:1893081](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1893081)