### PR TITLE
Store rev when pull-source on a subdir layer

### DIFF
--- a/charmtools/build/config.py
+++ b/charmtools/build/config.py
@@ -14,6 +14,7 @@ DEFAULT_IGNORES = [
     "*~",
     ".tox",
     "*.swp",
+    ".pull-source-rev",
 ]
 
 

--- a/charmtools/fetchers.py
+++ b/charmtools/fetchers.py
@@ -9,6 +9,7 @@ import tempfile
 
 import requests
 import yaml
+from path import Path as path
 
 
 log = logging.getLogger(__name__)
@@ -120,6 +121,9 @@ class Fetcher(object):
                     return rev_info.decode('utf8').strip()
             except FetchError:
                 continue
+        rev_file = path(dir_) / '.pull-source-rev'
+        if rev_file.exists():
+            return rev_file.read_text().strip()
         return self.revision
 
 

--- a/charmtools/pullsource.py
+++ b/charmtools/pullsource.py
@@ -57,6 +57,7 @@ import tempfile
 import textwrap
 
 import yaml
+from path import Path as path
 
 from charmtools import utils
 from charmtools.build import fetchers
@@ -205,6 +206,9 @@ def download_item(args):
     # Copy download dir to final destination dir
     shutil.copytree(download_dir, final_dest_dir, symlinks=True)
     rev = ' (rev: {})'.format(fetcher.revision) if fetcher.revision else ''
+    if fetcher.revision:
+        rev_file = path(final_dest_dir) / '.pull-source-rev'
+        rev_file.write_text(fetcher.revision)
     print('Downloaded {}{} to {}'.format(args.item, rev, final_dest_dir))
 
 


### PR DESCRIPTION
In addition to displaying the rev when using pull-source on a layer which uses the subdir field, we need to store it on disk for charm-build to use later in the build manifest.

Fixes [lp:1894331](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1894331)