### PR TITLE
Add reproducible charm build feature

### DIFF
--- a/charmtools/build/__init__.py
+++ b/charmtools/build/__init__.py
@@ -12,4 +12,3 @@ from charmtools.build.builder import (
     Fetched,
     log,
 )
-

--- a/charmtools/build/fetchers.py
+++ b/charmtools/build/fetchers.py
@@ -157,7 +157,6 @@ class LayerFetcher(fetchers.LocalFetcher):
 
     def fetch(self, dir_):
         if hasattr(self, "path"):
-            log.debug('Using fetcher: {}'.format(super(LayerFetcher, self)))
             return super(LayerFetcher, self).fetch(dir_)
         elif hasattr(self, "repo"):
             f, target = self._get_repo_fetcher_and_target(self.repo, dir_)
@@ -166,6 +165,10 @@ class LayerFetcher(fetchers.LocalFetcher):
                 log.debug('Adding branch: %s', self.BRANCH)
                 f.revision = self.BRANCH
             orig_res = res = f.fetch(dir_)
+            log.debug("url fetched (for lockfile): %s",
+                      getattr(f, 'fetched_url'))
+            self.fetched_url = getattr(f, 'fetched_url', None)
+            self.vcs = getattr(f, 'vcs', None)
             # make sure we save the revision of the actual repo, before we
             # start traversing subdirectories and moving contents around
             self.revision = self.get_revision(res)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ the command-line with:
 
    commands
    tactics
+   reproducible-charms
 
 
 .. toctree::

--- a/docs/reproducible-charms.rst
+++ b/docs/reproducible-charms.rst
@@ -65,7 +65,8 @@ If a lock file (``build.lock``) is available in the top layer, then it will be
 used to control the versions of the layers and modules *by default*.  i.e. the
 presence of the lock file controls the build.
 
-Two options are available to control the build when a lock file is present:
+Three options are available which can influence the build when a lock file is
+present:
 
  * ``--ignore-lock-file``
  * ``--use-lock-file-branches``

--- a/docs/reproducible-charms.rst
+++ b/docs/reproducible-charms.rst
@@ -1,0 +1,101 @@
+Reproducible Charms
+===================
+
+When building charms, multiple layers are brought together in an ordered,
+depth-first recursive fashion.  The individual files of each layer are merged,
+and then python modules are brought in according to ``wheelhouse.txt`` files
+that may exist in each layer.
+
+Layers (and Interfaces) are typically Git repositories, and by default the
+default branch (usually called ``master``) of the repository is fetched and
+used.
+
+Also, although the top level Python modules can be pinned in the
+``wheelhouse.txt`` files, any dependent modules are fetched as their latest
+versions.  This makes re-building a charm with the same layers and modules
+tricky, which may be required for stable charms.  It is possible, by populating
+layer and interface directories directly, and by pinning every Python module in
+a ``wheelhouse.txt`` override file that is passed using the
+``--wheelhouse-overrides`` option to the ``charm build`` command.
+
+An alternative strategy is to use a new feature of the ``charm build`` command
+which can generate a lock file that contains all of the layers and Python
+modules, and their versions.  This can then, for subsequent builds, be used to
+fetch the same layer versions and Python modules to re-create the charm.
+
+As the lock file is a ``JSON`` file, it can be manually edited to change a
+layer version if a new version of a stable charm is needed, or a python module
+can be changed.
+
+Additionally, it is possible to track a branch in the repository for a layer so
+that a stable (or feature) branch can be maintained and then charms rebuilt
+from that branch.
+
+The new options for this feature are:
+
+ * ``--write-lock-file``
+ * ``--use-lock-file-branches``
+ * ``--ignore-lock-file``
+
+
+Creating the lock file
+----------------------
+
+To create a lock file, the option ``--write-lock-file`` is passed to the
+``charm build`` command.  This option *automatically* ignores the existing lock
+file, and rebuilds the charm using the latest versions of the layers and the
+versions of the modules as determined in the various ``wheelhouse.txt`` files.
+
+Python module versions are also recorded.  If a VCS repository is used for the
+python module, then any branch specified is also recorded, along with the
+commit.
+
+At the end of the build, the lock file is written with all of the layer and
+Python module information.
+
+The lock file is installed *in* the base layer directory so that it can be
+committed into the VCS and used for subsequent builds.
+
+The name of the lock file is ``build.lock``.
+
+Rebuilding the charm from the lock file
+---------------------------------------
+
+If a lock file (``build.lock``) is available in the top layer, then it will be
+used to control the versions of the layers and modules *by default*.  i.e. the
+presence of the lock file controls the build.
+
+Two options are available to control the build when a lock file is present:
+
+ * ``--ignore-lock-file``
+ * ``--use-lock-file-branches``
+ * ``--wheelhouse-overrides``
+
+If the ``--ignore-lock-file`` option is used, then the charm is built as though
+there is no lock file.
+
+If the ``--use-lock-file-branches`` is used, then, for VCS items (layers,
+interfaces, and Python modules specified using a VCS string), then the branch
+(if there was one) will be used, rather than the commit version.  This can be
+used to track a branch in a layer or Python module.
+
+Note: if ``--wheelhouse-overrides`` is used, then that wheelhouse will override
+the lock file.  i.e. the lock file overrides the layers' ``wheelhouse.txt``
+file, and then the ``--wheelhouse-overrides`` then can override the lock-file.
+This is intentional to allow the build to perform specific overrides as
+needed.
+
+Other useful information
+------------------------
+
+This is the first iteration of 'reproducible charms'.  As such, only Git is
+supported as the VCS for the layers, and Git and Bazaar for Python modules.  A
+future iteration may support more VCS systems.
+
+Only the top layer is inspected for a ``build.lock`` file.  Any other layers
+are considered inputs and their ``build.lock`` files are ignored (if they are
+present).
+
+Also, regardless of the ``wheelhouse.txt`` layers, the lock file will override
+any changes that may be introduced in stable branches, if they are bing tracked
+using ``--use-lock-file-branches``.  This may lead to unexpected behaviour.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+keyring<21.0
 PyYAML>=3.11,<4.3
 blessings==1.6
 libcharmstore>=0.0.3
@@ -16,7 +17,6 @@ responses==0.3.0
 ruamel.yaml<0.16.0
 virtualenv>=1.11.4
 jsonschema==2.5.1
-keyring<21
 secretstorage<2.4
 six>=1.11.0
 dict2colander==0.2

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -82,6 +82,7 @@ class TestBuild(unittest.TestCase):
     @mock.patch("charmtools.build.builder.Builder.plan_version")
     def test_tester_layer(self, pv):
         bu = build.Builder()
+        bu.ignore_lock_file = True
         bu.log_level = "WARNING"
         bu.build_dir = self.build_dir
         bu.cache_dir = bu.build_dir / "_cache"
@@ -238,6 +239,7 @@ class TestBuild(unittest.TestCase):
                       }''',
                       content_type="application/json")
         bu = build.Builder()
+        bu.ignore_lock_file = True
         bu.log_level = "WARNING"
         bu.build_dir = self.build_dir
         bu.cache_dir = bu.build_dir / "_cache"
@@ -279,6 +281,7 @@ class TestBuild(unittest.TestCase):
                       }''',
                       content_type="application/json")
         bu = build.Builder()
+        bu.ignore_lock_file = True
         bu.log_level = "WARNING"
         bu.build_dir = self.build_dir
         bu.cache_dir = bu.build_dir / "_cache"
@@ -309,6 +312,7 @@ class TestBuild(unittest.TestCase):
     @mock.patch("charmtools.utils.Process")
     def test_pypi_installer(self, mcall, ph, pi, pv):
         bu = build.Builder()
+        bu.ignore_lock_file = True
         bu.log_level = "WARN"
         bu.build_dir = self.build_dir
         bu.cache_dir = bu.build_dir / "_cache"
@@ -335,6 +339,7 @@ class TestBuild(unittest.TestCase):
     def test_version_tactic_without_existing_version_file(self, mcall, ph, pi,
                                                           get_sha):
         bu = build.Builder()
+        bu.ignore_lock_file = True
         bu.log_level = "WARN"
         bu.build_dir = self.build_dir
         bu.cache_dir = bu.build_dir / "_cache"
@@ -364,6 +369,7 @@ class TestBuild(unittest.TestCase):
     @mock.patch("charmtools.build.builder.Builder.plan_hooks")
     def test_version_tactic_missing_cmd(self, ph, pi):
         bu = build.Builder()
+        bu.ignore_lock_file = True
         bu.log_level = "WARN"
         bu.build_dir = self.build_dir
         bu.cache_dir = bu.build_dir / "_cache"
@@ -395,6 +401,7 @@ class TestBuild(unittest.TestCase):
     def test_version_tactic_with_existing_version_file(self, mcall, ph, pi,
                                                        get_sha, read):
         bu = build.Builder()
+        bu.ignore_lock_file = True
         bu.log_level = "WARN"
         bu.build_dir = self.build_dir
         bu.cache_dir = bu.build_dir / "_cache"
@@ -583,6 +590,7 @@ class TestBuild(unittest.TestCase):
                              url=tactics[0])
 
         builder = build.builder.Builder()
+        builder.ignore_lock_file = True
         builder.build_dir = self.build_dir
         builder.cache_dir = builder.build_dir / "_cache"
         builder.charm = 'foo'


### PR DESCRIPTION
This feature adds some command line options to allow the generation of
the build.lock file in the top layer.  This can then be used to rebuild
the charm with the exact same set of layers and python modules. Also the
ability to track a specific branch is also enabled.

Description of change

## Checklist

 - [ ] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [ ] Does your code pass `make test`?
