### PR TITLE
Fix TypeError from linter on X.Y min-juju-version

### DIFF
--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -800,8 +800,8 @@ def validate_min_juju_version(charm, linter):
     if 'min-juju-version' not in charm:
         return
 
-    pattern = r'^(\d{1,9})\.(\d{1,9})(\.|-(\w+))(\d{1,9})(\.\d{1,9})?$'
-    match = re.match(pattern, charm['min-juju-version'])
+    pattern = r'(\d{1,9})\.(\d{1,9})(?:\.|-([a-z]+))(\d{1,9})(\.\d{1,9})?'
+    match = re.match(pattern, str(charm['min-juju-version']))
     if not match:
         linter.err('min-juju-version: invalid format, try X.Y.Z')
         return


### PR DESCRIPTION
Because YAML can end up treating a bare X.Y number as a float rather than a string, the linter was blowing up with an exception
(`TypeError: expected string or bytes-like object`) instead of a useful error about the format of the min-juju-version field.

Drive-by: Update to match [current regexp from upstream][regexp].

[regexp]: https://github.com/juju/version/blob/d414598/version.go#L108