### PR TITLE
Align setup.py to requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'virtualenv>=1.11.4',
         'colander<=1.7.0',
         'jsonschema<=2.5.1',
+        'keyring<21',
         'secretstorage<2.4',
         'dict2colander==0.2',
         'vergit>=1.0.0,<2.0.0',


### PR DESCRIPTION
keyring 21 depends on secretstorage>=3.2, so if we pin
secretstorage<2.4 we also must pin keyring<21. This is
what we do in requirements.txt already so this commit
is just aligning setup.py.

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
