### PR TITLE
Fix exception rendering "already promulgated" error

### DIFF
--- a/charmtools/promulgation.py
+++ b/charmtools/promulgation.py
@@ -77,9 +77,10 @@ def promulgate():
                             promulgated_id, '--format=json'],
                            stdout=PIPE, stderr=PIPE)
     if promulgated_show.returncode == 0:
-        promulgated_info = json.loads(promulgated_show.decode('utf8'))
+        promulgated_info = json.loads(promulgated_show.stdout.decode('utf8'))
         owner = promulgated_info['owner']['User']
-        _fail(f'{promulgated_id} is already owned by {owner}')
+        _fail(f'{promulgated_id} is already owned by {owner}; '
+              f'you will need to unpromulgate first to change owner')
 
     res = run([_bin('bhttp'), 'put', '-j', _url(charm_id),
                'Promulgated:=true'])


### PR DESCRIPTION
Minor issue in the code for reporting the error case where you try to promulgate a charm where one is already promgulated from another namespace. Also improve the error message to indicate the correct action to take.