### PR TITLE
Add option to create .charm file

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -1140,8 +1140,8 @@ def main(args=None):
                         help='Same as --log-level=DEBUG')
     parser.add_argument('-c', '--force-color', action="store_true",
                         help="Force raw output (color)")
-    parser.add_argument('--charm-file', '-F', action="store_true",
-                        help="Create a .charm file in the current directory")
+    parser.add_argument('--charm-file', '-F', action='store_true',
+                        help='Create a .charm file in the current directory')
     parser.add_argument('charm', nargs="?", default=".", type=path,
                         help='Source directory for charm layer to build '
                              '(default: .)')

--- a/charmtools/build/config.py
+++ b/charmtools/build/config.py
@@ -15,6 +15,7 @@ DEFAULT_IGNORES = [
     ".tox",
     "*.swp",
     ".pull-source-rev",
+    "*.charm",
 ]
 
 


### PR DESCRIPTION
The new pattern used by `charmcraft` is to create a file named `{charm-name}.charm` in the current directory, which is a zip archive of the charm. This adds a `--charm-file` (`-F`) option to also create that file in the same way.