### PR TITLE
Allow blessings 1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'pyyaml>=5.0,<6.0',
         'requests>=2.0.0,<3.0.0',
         'libcharmstore',
-        'blessings<=1.6',
+        'blessings<=1.7',
         'ruamel.yaml<0.16.0',
         'pathspec<=0.3.4',
         'otherstuf<=1.1.0',


### PR DESCRIPTION
Blessings 1.6 fails to build under modern setuptools. 1.7 is a minor update that moves from using `2to3` to `six` (dropping Python 2.6 and 3.3 support) with no other functional change.

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [ ] Does your code pass `make test`?
