### PR TITLE
Add warning message if series is in metadata.yaml

### DIFF
--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -807,22 +807,20 @@ def validate_min_juju_version(charm, linter):
 
 
 def validate_series(charm, linter):
-    """Validate supported series list in charm metadata.
+    """Validate series list in charm metadata.
 
-    We don't validate the actual series names because:
-
-    1. `charm push` does that anyway
-    2. our list of valid series would be constantly falling out-of-date
+    The `series` parameter is deprecated because charmcraft ignores it and
+    uses `bases` from `charmcraft.yaml`. This function checks if the series
+    is in metadata.yaml and displays a warning message if so.
 
     :param charm: dict of charm metadata parsed from metadata.yaml
     :param linter: :class:`CharmLinter` object to which info/warning/error
         messages will be written
 
     """
-    if 'series' not in charm:
-        linter.err('missing series: must be a list of series names')
-    elif not isinstance(charm['series'], list):
-        linter.err('series: must be a list of series names')
+    if 'series' in charm:
+        linter.warn('DEPRECATED: series parameter is ignored by charmcraft,'
+                    'use bases in charmcraft.yaml')
 
 
 def validate_storage(charm, linter, proof_extensions=None):

--- a/tests/test_charm_proof.py
+++ b/tests/test_charm_proof.py
@@ -1256,31 +1256,12 @@ class FunctionsValidationTest(TestCase):
 
 
 class SeriesValidationTest(TestCase):
-    def test_series_not_list(self):
-        """Charm has a series key, but the value is not a list."""
+    def test_series(self):
+        """Charm does have a series key."""
         linter = Mock()
-        charm = {
-            'series': 'trusty',
-        }
+        charm = {"series": []}
         validate_series(charm, linter)
-        linter.err.assert_called_once_with(
-                'series: must be a list of series names')
-
-    def test_series_list(self):
-        """Charm has a series key that is a list."""
-        linter = Mock()
-        charm = {
-            'series': ['trusty'],
-        }
-        validate_series(charm, linter)
-        self.assertFalse(linter.err.called)
-
-    def test_no_series(self):
-        """Charm does not have a series key."""
-        linter = Mock()
-        charm = {}
-        validate_series(charm, linter)
-        self.assertTrue(linter.err.called)
+        self.assertTrue(linter.warn.called)
 
 
 class TermsValidationTest(TestCase):


### PR DESCRIPTION
The charmcraft is using bases in charmcraft.yaml instead of series in
metadata.yaml, so the series should not be used anymore.

fixes: #615 

Description of change

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
