### PR TITLE
Change series lint from warn to info message

### DIFF
--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -811,7 +811,9 @@ def validate_series(charm, linter):
 
     The `series` parameter is deprecated because charmcraft ignores it and
     uses `bases` from `charmcraft.yaml`. This function checks if the series
-    is in metadata.yaml and displays a warning message if so.
+    is in metadata.yaml and displays an info message if so. Note that it is not
+    a warning as that causes an error in the charm proof which isn't what is
+    wanted.
 
     :param charm: dict of charm metadata parsed from metadata.yaml
     :param linter: :class:`CharmLinter` object to which info/warning/error
@@ -819,7 +821,7 @@ def validate_series(charm, linter):
 
     """
     if 'series' in charm:
-        linter.warn('DEPRECATED: series parameter is ignored by charmcraft,'
+        linter.info('DEPRECATED: series parameter is ignored by charmcraft,'
                     'use bases in charmcraft.yaml')
 
 

--- a/tests/test_charm_proof.py
+++ b/tests/test_charm_proof.py
@@ -1261,7 +1261,7 @@ class SeriesValidationTest(TestCase):
         linter = Mock()
         charm = {"series": []}
         validate_series(charm, linter)
-        self.assertTrue(linter.warn.called)
+        self.assertTrue(linter.info.called)
 
 
 class TermsValidationTest(TestCase):


### PR DESCRIPTION
As a 'warn' the message causes the charm proof to fail which will fail
most builds.  This patch changes it to 'info'.

Description of change

## Checklist

 - [ ] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [ ] Does your code pass `make test`?
