### PR TITLE
Prune GIT environment variables when using Python from buildenv

### DIFF
--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -1073,7 +1073,8 @@ class WheelhouseTactic(ExactMatch, Tactic):
             return os.environ.copy()
 
         env = os.environ.copy()
-        for key in ('PREFIX', 'PYTHONHOME', 'PYTHONPATH'):
+        for key in ('PREFIX', 'PYTHONHOME', 'PYTHONPATH',
+                    'GIT_TEMPLATE_DIR', 'GIT_EXEC_PATH'):
             if key in env:
                 del(env[key])
         env['PATH'] = ':'.join([


### PR DESCRIPTION
At present we call out to Python provided by the build environment to create a correct wheelhouse.

However, we are not pruning GIT related environment variables set by the snap.  This in turn makes git clone fail when the `git` binary from the build environment attempts to use git resources in the snap, which may be of a different version.

Fixes #632