### PR TITLE
Clear environment variables when running apt

### DIFF
--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -785,7 +785,7 @@ class Builder(object):
                 and (os.environ.get('CRAFT_PART_NAME', None)
                      or os.environ.get('CHARMCRAFT_PART_NAME', None))):
             log.warning('Probably running as root in charmcraft, proactively '
-                        'installing the `git` and `virutalenv` packages.')
+                        'installing the `git` and `virtualenv` packages.')
             subprocess.run(('apt', '-y', 'install', 'git', 'virtualenv'), check=True, env={})
 
     def generate(self):

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -786,7 +786,7 @@ class Builder(object):
                      or os.environ.get('CHARMCRAFT_PART_NAME', None))):
             log.warning('Probably running as root in charmcraft, proactively '
                         'installing the `git` and `virutalenv` packages.')
-            subprocess.run(('apt', '-y', 'install', 'git', 'virtualenv'), check=True)
+            subprocess.run(('apt', '-y', 'install', 'git', 'virtualenv'), check=True, env={})
 
     def generate(self):
         layers = self.fetch()


### PR DESCRIPTION
When running 'apt' within the snap the environment variables set will make it run with the python version embedded in the snap instead of the system's tools, this will make the package installation fail with the following error:

    Setting up python3-pkg-resources (45.2.0-1) ...
    Fatal Python error: init_sys_streams: can't initialize sys standard streams
    Python runtime state: core initialized
    Traceback (most recent call last):
    File "/snap/charm/677/usr/lib/python3.10/io.py", line 54, in <module>
    ImportError: cannot import name 'text_encoding' from 'io' (unknown location)
    dpkg: error processing package python3-pkg-resources (--configure):
    installed python3-pkg-resources package post-installation script subprocess returned error exit status 1

Test case:

git clone https://opendev.org/openstack/charm-octavia-dashboard.git cd charm-octavia-dashboard
git checkout e1f50a2
tox -e build  # use charmcraft 1.5

Description of change

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
