### PR TITLE
Add option to upgrade core deps in build venv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,17 +54,6 @@ jobs:
       with:
         repository: juju-solutions/layer-basic
 
-    - name: Fixup wheelhouse
-      run: |
-        set -euxo pipefail
-        cat << EOF | tee -a tests/charm-minimal/wheelhouse.txt
-        # https://github.com/pallets/jinja/issues/1496
-        #
-        # We ought to teach charm-tools to seed the virtualenv used to build
-        # wheels with newer versions of pip and setuptools.
-        Jinja2<3
-        EOF
-
     - name: Download built charm snap
       uses: actions/download-artifact@v3
       with:
@@ -90,6 +79,7 @@ jobs:
             reactive-charm-build-arguments:
               - -v
               - --binary-wheels-from-source
+              - --upgrade-buildvenv-core-deps
             build-packages:
               - python3-dev
               - libpq-dev

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -1205,6 +1205,11 @@ def main(args=None):
                         default=False,
                         help='Use Python and associated tools from the snap '
                              'when building the wheelhouse.')
+    parser.add_argument('--upgrade-buildvenv-core-deps', action='store_true',
+                        default=False,
+                        help='Upgrade core dependencies in virtualenv used to '
+                        'build/download wheels: pip setuptools to the latest '
+                        'version in PyPI.')
     parser.add_argument('charm', nargs="?", default=".", type=path,
                         help='Source directory for charm layer to build '
                              '(default: .)')
@@ -1226,6 +1231,7 @@ def main(args=None):
     WheelhouseTactic.binary_build = build.binary_wheels
     WheelhouseTactic.binary_build_from_source = build.binary_wheels_from_source
     WheelhouseTactic.use_python_from_snap = build.use_python_from_snap
+    WheelhouseTactic.upgrade_deps = build.upgrade_buildvenv_core_deps
 
     configLogging(build)
 

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -651,3 +651,36 @@ def host_env():
         for element in env['PATH'].split(':')
         if not element.startswith('/snap/charm/')])
     return env
+
+
+def upgrade_venv_core_packages(venv_dir, env=None):
+    """Upgrade core dependencies in venv.
+
+    :param venv_dir: Full path to virtualenv in which packages will be upgraded
+    :type venv_dir: str
+    :param env: Environment to use when executing command
+    :type env: Optional[Dict[str,str]]
+    :returns: This function is called for its side effect
+    """
+    log.debug('Upgrade pip and setuptools in virtualenv "{}"'.format(venv_dir))
+    # We can replace this with a call to `python3 -m venv --upgrade-deps` once
+    # support for bionic and focal has been removed.
+    Process((os.path.join(venv_dir, 'bin/pip'),
+             'install', '-U', 'pip', 'setuptools'),
+            env=env).exit_on_error()()
+
+
+def get_venv_package_list(venv_dir, env=None):
+    """Get list of packages and their version in virtualenv.
+
+    :param venv_dir: Full path to virtualenv in which packages will be listed
+    :type venv_dir: str
+    :param env: Environment to use when executing command
+    :type env: Optional[Dict[str,str]]
+    :returns: List of packages with their versions
+    :rtype: str
+    """
+    result = Process((os.path.join(venv_dir, 'bin/pip'), 'list'), env=env)()
+    if result:
+        return result.output
+    result.exit_on_error()


### PR DESCRIPTION
Some packages may require newer versions of core dependencies for successful execution of the `pip download` or `pip wheel` commands. Most notable example is Jinja2 and MarkupSafe when installed on Focal ref pallets/jinja#1496.

At this stage of the process the input from the charm wheelhouse.txt is not sufficient.

Add an option to upgrade pip and setuptools in the build venv to deal with these situations.

Fixes: #646
Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>