### PR TITLE
Fix a couple of pip requirement lines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'pathspec<0.11;python_version >= "3.7"',
         'otherstuf<=1.1.0',
         'path.py>=10.5,<13',
-        'pip>=1.5.4<23',
+        'pip>=1.5.4,<23',
         'jujubundlelib<0.6',
         'virtualenv>=1.11.4,<21',
         'colander<1.9',

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -486,7 +486,7 @@ class TestBuild(unittest.TestCase):
                         '',
                         '# --wheelhouse-overrides',
                         'git+https://github.com/me/qux#egg=qux',
-                        'setuptools_scm>=3.0<=3.4.1',
+                        'setuptools_scm>=3.0,<=3.4.1',
                         '',
                     ])
 

--- a/tests/wh-over.txt
+++ b/tests/wh-over.txt
@@ -1,2 +1,2 @@
 git+https://github.com/me/qux#egg=qux
-setuptools_scm>=3.0<=3.4.1
+setuptools_scm>=3.0,<=3.4.1


### PR DESCRIPTION
A change in the strictness of how pip requirements lines are parsed means that the lib needs a tactical fix to enable testing to move forwards.  A more complete fix is to remove the upper bounds and the main development branch.

