### PR TITLE
setup: Update charm-tools pin set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,10 @@ jobs:
         sudo lxd init --auto
         # This is a throw-away CI environment, do not do this at home
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
+        # Fixup iptables forwarding issues from LXD containers with a flush and
+        # re-create of rules.
+        sudo iptables -F FORWARD
+        sudo iptables -P FORWARD ACCEPT
     - name: Checkout layer-basic
       uses: actions/checkout@v2
       with:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
         'cheetah3>=3.0.0,<4.0',
-        'pyyaml>=5.0,<6.0',
+        'pyyaml>=5.0,!=5.4.0,!=5.4.1,<6.0',
         'requests>=2.0.0,<3.0.0',
         'blessings<2.0',
         'ruamel.yaml<0.16.0;python_version < "3.7"',
@@ -56,7 +56,7 @@ setup(
         'jujubundlelib<0.6',
         'virtualenv>=1.11.4,<21',
         'colander<1.9',
-        'jsonschema<5.0',
+        'jsonschema<4.18.0',
         'keyring<24',
         'secretstorage<3.4',
         'dict2colander==0.2',


### PR DESCRIPTION
pyyaml 5.4.0 and 5.4.1 are broken with cython 3
https://github.com/yaml/pyyaml/issues/724

jsonschema 4.18.0 depends on Rust (via rpds-py)
