### PR TITLE
setup: Update charm-tools pin set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'launchpadlib<1.11',
         'cheetah3>=3.0.0',
-        'pyyaml>=5.0,<6.0',
+        'pyyaml>=5.0,!=5.4.0,!=5.4.1,<6.0',
         'requests>=2.0.0,<3.0.0',
         'libcharmstore',
         'blessings',


### PR DESCRIPTION
pyyaml 5.4.0 and 5.4.1 are broken with cython 3
yaml/pyyaml#724

Equivalent change to #659 for the 2.8 branch.

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
