### PR TITLE
setup: Update pin PyYAML

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
         'cheetah3>=3.0.0,<4.0',
-        'pyyaml>=5.0,!=5.4.0,!=5.4.1,<6.0',
+        'pyyaml>=5.0,!=5.4.0,!=5.4.1,!=6.0,<7.0',
         'requests>=2.0.0,<3.0.0',
         'blessings<2.0',
         'ruamel.yaml<0.16.0;python_version < "3.7"',


### PR DESCRIPTION
Allow the use of PyYAML 6.x with the exception of PyYAML-6.0 which has a broken build dependency relation to Cython.

This allows migrating away from PyYAML-5.3.1 which has known security bugs[0]

[0] https://security.snyk.io/package/pip/PyYAML/5.3.1

Description of change

## Checklist

 - [ ] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [ ] Does your code pass `make test`?
