### PR TITLE
[2.8] Fix issues with tox targets lint & docs

### DIFF
--- a/charmtools/build/__init__.py
+++ b/charmtools/build/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# flake8: noqa
 from __future__ import absolute_import
 
 import charmtools.build.tactics

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -123,8 +123,6 @@ class Fetched(Configable):
             # using the revision as the branch so that things do at least
             # build.
             self.branch = self.revision
-            # self.branch = fetcher.get_branch_for_revision(self.directory,
-                                                          # self.revision)
 
         if not self.directory.exists():
             raise BuildError(

--- a/charmtools/bundles.py
+++ b/charmtools/bundles.py
@@ -85,7 +85,9 @@ class Bundle(object):
     def is_v4(self, data=None):
         if data is None:
             data = self.bundle_file()
-        v4_keys = {'applications', 'services', 'relations', 'machines', 'series'}
+        v4_keys = {
+            'applications', 'services', 'relations', 'machines', 'series'
+        }
         bundle_keys = set(data.keys())
         return bool(v4_keys & bundle_keys)
 

--- a/charmtools/charms.py
+++ b/charmtools/charms.py
@@ -129,7 +129,7 @@ class CharmLinter(Linter):
         for r in relations.items():
             if r[0].startswith('juju-'):
                 self.info('juju-* is a reserved relation name')
-            if type(r[1]) != dict:
+            if not isinstance(r[1], dict):
                 self.err("relation %s is not a map" % (r[0]))
             else:
                 if 'scope' in r[1]:
@@ -379,14 +379,14 @@ class Charm(object):
                             with open(readme_path) as r:
                                 readme_content = r.read()
                                 lc = 0
-                                for l in bad_lines:
-                                    if not len(l):
+                                for bl in bad_lines:
+                                    if not len(bl):
                                         continue
                                     lc += 1
-                                    if l in readme_content:
+                                    if bl in readme_content:
                                         err_msg = ('%s includes boilerplate: '
                                                    '%s')
-                                        lint.warn(err_msg % (readme, l))
+                                        lint.warn(err_msg % (readme, bl))
                 except IOError as e:
                     lint.warn(
                         "Error while opening %s (%s)" %
@@ -395,7 +395,7 @@ class Charm(object):
                 lint.warn("no README file")
 
             subordinate = charm.get('subordinate', False)
-            if type(subordinate) != bool:
+            if type(subordinate) is not bool:
                 lint.err("subordinate must be a boolean value")
 
             # All charms should provide at least one thing
@@ -977,9 +977,11 @@ def validate_functions(functions, function_hooks, linter):
             continue
         h = os.path.join(function_hooks, k)
         if not os.path.isfile(h):
-            linter.warn('functions.{0}: functions/{0} does not exist'.format(k))
+            linter.warn('functions.{0}: functions/{0} does not exist'
+                        .format(k))
         elif not os.access(h, os.X_OK):
-            linter.err('functions.{0}: functions/{0} is not executable'.format(k))
+            linter.err('functions.{0}: functions/{0} is not executable'
+                       .format(k))
 
 
 def validate_maintainer(charm, linter):
@@ -1027,12 +1029,12 @@ def validate_categories_and_tags(charm, linter):
 
     if 'tags' in charm:
         tags = charm['tags']
-        if type(tags) != list or tags == []:
+        if not isinstance(tags, list) or tags == []:
             linter.warn('Metadata field "tags" must be a non-empty list')
 
     if 'categories' in charm:
         categories = charm['categories']
-        if type(categories) != list or categories == []:
+        if not isinstance(categories, list) or categories == []:
             # The category names are not validated because they may
             # change.
             linter.warn(

--- a/charmtools/generators/utils.py
+++ b/charmtools/generators/utils.py
@@ -49,7 +49,7 @@ def apt_fill(package):
         v['summary'] = p.summary
         v['description'] = textwrap.fill(p.description, width=72,
                                          subsequent_indent='  ')
-    except:
+    except Exception:
         log.info(
             "No %s in apt cache; creating an empty charm instead.", package)
         v['summary'] = '<Fill in summary here>'
@@ -69,7 +69,7 @@ def portable_get_maintainer():
 
             if not len(name):
                 name = pwd.getpwuid(os.getuid())[0]
-        except:
+        except Exception:
             name = 'Your Name'
 
     if not len(name):

--- a/charmtools/proof.py
+++ b/charmtools/proof.py
@@ -53,7 +53,7 @@ def proof(path, is_bundle, debug):
         except Exception:
             try:
                 c = Bundle(path, debug)
-            except Exception as e:
+            except Exception:
                 return ["FATAL: No bundle.yaml (Bundle) or metadata.yaml "
                         "(Charm) found, cannot proof"], 200
     else:

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -644,7 +644,7 @@ def host_env():
     for key in ('PREFIX', 'PYTHONHOME', 'PYTHONPATH',
                 'GIT_TEMPLATE_DIR', 'GIT_EXEC_PATH'):
         if key in env:
-            del(env[key])
+            del env[key]
     env['PATH'] = ':'.join([
         element
         for element in env['PATH'].split(':')

--- a/charmtools/version.py
+++ b/charmtools/version.py
@@ -52,7 +52,7 @@ def cached_charmstore_client_version():
             charm_ver = 'unavailable'
     except ImportError:
         charm_ver = 'unavailable'
-    except:
+    except Exception:
         charm_ver = 'error'
 
     return _add_snap_rev({'version': charm_ver})

--- a/docs/_extensions/automembersummary.py
+++ b/docs/_extensions/automembersummary.py
@@ -44,7 +44,8 @@ class AutoMemberSummary(Autosummary):
 
         def _get_items(name):
             _items = super(AutoMemberSummary, self).get_items([shorten + name])
-            if self.result.data and ".. deprecated::" in self.result.data[0]:
+            if (self.bridge.result.data and
+                    ".. deprecated::" in self.bridge.result.data[0]):
                 # don't show deprecated classes / functions in summary
                 return
             for dn, sig, summary, rn in _items:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -90,7 +90,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,8 @@ detailed-errors=1
 #pdb-failures=1
 logging-level=INFO
 
+[flake8]
+exclude =
+    charmtools/diff_match_patch.py
+    charmtools/templates
 


### PR DESCRIPTION
* `lint` target: this ignores the vendored in
  `charmtools/diff_match_patch.py` file which uses completely
  non-standard indenting (2 spaces). It also fixes various issues around
  bare exceptions, indendation and equality tests on types.

* `docs` target: this fixes the custom
  /docs/_extensions/automembersummary.py extension to be able to use a
  more recent version of sphinx. This fixes a long-standing broken
  sphinx docs generation issue.

(cherry-picked from b7e51d5cf93070762215ebec06bb13e471d6511c)
(charmtools/build/tactics.py needed revisions to pick.)

Description of change

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
