### PR TITLE
Upgrade setuptools

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,6 +68,12 @@ parts:
       - MAKEFLAGS: -j$(nproc)
       - CFLAGS: -I/usr/include/python3.10
     override-build: |
+      # Upgrading setuptools helps to fix:
+      #
+      #   ERROR: setuptools==59.6.0 is used in combination with setuptools_scm>=8.x
+      #   Your build configuration is incomplete and previously worked by accident!
+      #   setuptools_scm requires setuptools>=61
+      pip install --upgrade setuptools
       pip install \
           --no-binary :all: \
           --prefix $CRAFT_PART_INSTALL/usr \
@@ -87,10 +93,10 @@ parts:
 
       PYTHONHOME=$CRAFT_PART_INSTALL \
           PYTHONPATH=$CRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$CRAFT_PART_INSTALL/usr/lib/python3.10/site-packages:$CRAFT_PART_INSTALL/usr/lib/python3.10:$CRAFT_PART_INSTALL/usr/lib/python3.10/lib-dynload:$CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages \
-          vergit --format=json > $CRAFT_PART_INSTALL/charm-tools-version
+          $CRAFT_PART_INSTALL/usr/local/bin/vergit --format=json > $CRAFT_PART_INSTALL/charm-tools-version
       version=$(PYTHONHOME=$CRAFT_PART_INSTALL \
                 PYTHONPATH=$CRAFT_PART_INSTALL/usr/lib/python3/dist-packages:$CRAFT_PART_INSTALL/usr/lib/python3.10/site-packages:$CRAFT_PART_INSTALL/usr/lib/python3.10:$CRAFT_PART_INSTALL/usr/lib/python3.10/lib-dynload:$CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages \
-                vergit)
+                $CRAFT_PART_INSTALL/usr/local/bin/vergit)
       craftctl set version=$version
     override-stage: |
       find $CRAFT_PART_INSTALL -type f -print0 | xargs -0 sed -i '1 s/^#\!.*python$/#\!\/usr\/bin\/env python3/'


### PR DESCRIPTION
setuptools-scm depends on setuptools>=61, while the one installed in the building environment is setuptools-59.x which comes from the deb package available in Ubuntu-22.04.

This change upgrades setuptools to allow the building to succeed. Also uses an absolute path when running `vergit` to fix a "command not found" error.

Fixes #666

Description of change

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [] Does this patch have code coverage?
 - [] Does your code pass `make test`?
