### PR TITLE
setup: pin ruamel.yaml to <0.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'blessings',
         'ruamel.yaml<0.16.0;python_version < "3.7"',
         'pathspec<=0.3.4;python_version < "3.7"',
-        'ruamel.yaml;python_version >= "3.7"',
+        'ruamel.yaml<0.18;python_version >= "3.7"',
         'pathspec;python_version >= "3.7"',
         'otherstuf<=1.1.0',
         'path.py>=10.5',


### PR DESCRIPTION
ruamel.yaml 0.18 hard deprecated the old PyYAML functions removing
yaml.safe_load among many others. This causes charm-build to exit
sometimes without a visible error.

Fixes: #668
Reference: https://pypi.org/project/ruamel.yaml/0.18.0/
