### PR TITLE
Use bhttp from latest/edge

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,8 +5,6 @@ description: charmstore-client and charm-tools
 confinement: classic
 grade: stable
 base: core18
-architectures:
-  - amd64
 apps:
   charm:
     command: bin/wrappers/charm
@@ -24,7 +22,7 @@ parts:
       - bzr
       - python3-pip
     stage-snaps:
-      - bhttp
+      - bhttp/latest/edge
     override-build: |
       snapcraftctl build
       pip3 install vergit
@@ -32,7 +30,7 @@ parts:
   bhttp:
     plugin: nil
     stage-snaps:
-      - bhttp
+      - bhttp/latest/edge
     stage:
       - bin/bhttp
   charm-tools:


### PR DESCRIPTION
the bhttp snap is available in latest/edge for the architectures we care
about. This enables the building of charm-tools as a snap in non-amd64
architectures.

Closes #666 

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [ ] Does your code pass `make test`?
