### PR TITLE
Python 3.12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version:
+          - '3.8'
+          - '3.10'
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
-          - '3.10'
+          - '3.8'   # focal
+          - '3.10'  # jammy
+          - '3.12'  # noble
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,8 @@ jobs:
         name: charm-snap
         path: tests/charm-minimal/charm-snap
 
-    - name: Build reactive charm with charmcraft
+    - name: Build reactive charm with charmcraft-2.x
+      if: ${{ matrix.charmcraft_channel == '2.x/stable' }}
       run: |
         set -euxo pipefail
         sudo snap install --classic --channel ${{ matrix.charmcraft_channel }} charmcraft
@@ -108,6 +109,37 @@ jobs:
             architectures: [amd64]
         EOF
         charmcraft pack -p tests/charm-minimal -v
+    - name: Build reactive charm with charmcraft-3.x
+      if: ${{ matrix.charmcraft_channel == '3.x/beta' }}
+      run: |
+        set -euxo pipefail
+        sudo snap install --classic --channel ${{ matrix.charmcraft_channel }} charmcraft
+        cat << EOF | tee tests/charm-minimal/charmcraft.yaml
+        type: charm
+        parts:
+          charm-tools:
+            plugin: nil
+            override-build: |
+              ls -lR \$CRAFT_PROJECT_DIR/
+              snap install --dangerous --classic /root/project/charm-snap/charm_0.0.0_amd64.snap
+              rm -rf \$CRAFT_PROJECT_DIR/parts/charm/src/charm-snap
+          charm:
+            after: [charm-tools]
+            source: .
+            plugin: reactive
+            reactive-charm-build-arguments:
+              - -v
+              - --binary-wheels-from-source
+              - --upgrade-buildvenv-core-deps
+            build-packages:
+              - python3-dev
+              - libpq-dev
+        base: ubuntu@24.04
+        platforms:
+          amd64:
+        EOF
+        charmcraft pack -p tests/charm-minimal -v
+        mv minimal_amd64.charm minimal_ubuntu-24.04-amd64.charm
     ## action to interactively debug CI failures.
     # - name: Setup upterm session
     #   if: failure()
@@ -126,3 +158,4 @@ jobs:
           minimal_ubuntu-18.04-amd64.charm
           minimal_ubuntu-20.04-amd64.charm
           minimal_ubuntu-22.04-amd64.charm
+          minimal_ubuntu-24.04-amd64.charm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,11 @@ jobs:
         path: ${{ steps.snap-build.outputs.snap }}
 
   integration:
+    strategy:
+      matrix:
+        charmcraft_channel:
+          - "2.x/stable"
+          - "3.x/beta"
     name: Integration test
     needs: build
     runs-on: ubuntu-latest
@@ -70,7 +75,7 @@ jobs:
     - name: Build reactive charm with charmcraft
       run: |
         set -euxo pipefail
-        sudo snap install --classic --channel latest/edge charmcraft
+        sudo snap install --classic --channel ${{ matrix.charmcraft_channel }} charmcraft
         cat << EOF | tee tests/charm-minimal/charmcraft.yaml
         type: charm
         parts:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,7 @@ jobs:
           charm-tools:
             plugin: nil
             override-build: |
+              ls -lR \$CRAFT_PROJECT_DIR/
               snap install --dangerous --classic \$CRAFT_PROJECT_DIR/parts/charm/src/charm-snap/*.snap
               rm -rf \$CRAFT_PROJECT_DIR/parts/charm/src/charm-snap
           charm:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
             plugin: nil
             override-build: |
               ls -lR \$CRAFT_PROJECT_DIR/
-              snap install --dangerous --classic \$CRAFT_PROJECT_DIR/parts/charm/src/charm-snap/*.snap
+              snap install --dangerous --classic /root/project/charm-snap/charm_0.0.0_amd64.snap
               rm -rf \$CRAFT_PROJECT_DIR/parts/charm/src/charm-snap
           charm:
             after: [charm-tools]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,10 @@ jobs:
             architectures: [amd64]
         EOF
         charmcraft pack -p tests/charm-minimal -v
+    ## action to interactively debug CI failures.
+    # - name: Setup upterm session
+    #   if: failure()
+    #   uses: lhotari/action-upterm@v1
     - name: Upload charmcraft execution logs
       if: always()
       uses: actions/upload-artifact@v3

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -1253,6 +1253,9 @@ class WheelhouseTactic(ExactMatch, Tactic):
             ).exit_on_error()()
         if self.upgrade_deps:
             utils.upgrade_venv_core_packages(self._venv, env=self._get_env())
+        elif utils.get_python_version(self._venv,
+                                      env=self._get_env()) >= utils.PY312:
+            log.debug('Skip pinning of setuptools, because Python>=3.12')
         else:
             utils.pin_setuptools_for_pep440(self._venv, env=self._get_env())
         log.debug(

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -1,4 +1,4 @@
-from inspect import getargspec
+from inspect import getfullargspec
 import errno
 import json
 import logging
@@ -43,7 +43,7 @@ class Tactic(object):
         given entity.
         """
         for candidate in current_config.tactics + DEFAULT_TACTICS:
-            argspec = getargspec(candidate.trigger)
+            argspec = getfullargspec(candidate.trigger)
             if len(argspec.args) == 2:
                 # old calling convention
                 name = candidate.__name__

--- a/charmtools/utils.py
+++ b/charmtools/utils.py
@@ -20,6 +20,7 @@ import pathspec
 from path import Path as path
 
 log = logging.getLogger('utils')
+PY312 = (3, 12, 0)
 
 
 @contextmanager
@@ -681,8 +682,8 @@ def pin_setuptools_for_pep440(venv_dir, env=None):
     :type env: Optional[Dict[str,str]]
     :returns: This function is called for its side effect
     """
-    log.debug('Pinning setuptools < 67 for pep440 non compliant packages "{}"'
-              .format(venv_dir))
+    log.info('Pinning setuptools < 67 for pep440 non compliant packages "{}"'
+             .format(venv_dir))
     Process((os.path.join(venv_dir, 'bin/pip'),
              'install', '-U', 'pip<23.1', 'setuptools<67'),
             env=env).exit_on_error()()
@@ -702,3 +703,24 @@ def get_venv_package_list(venv_dir, env=None):
     if result:
         return result.output
     result.exit_on_error()
+
+
+def get_python_version(venv_dir, env=None):
+    """Get the Python interpreter version in the virtualenv.
+
+    :param venv_dir: Full path to virtualenv in which packages will be listed
+    :type venv_dir: str
+    :param env: Environment to use when executing command
+    :type env: Optional[Dict[str,str]]
+    :returns: Tuple with major, minor and microversion
+    :rtype: Tuple[str]
+    """
+    result = Process((os.path.join(venv_dir, 'bin/python3'), '--version'),
+                     env=env)()
+    m = re.match(r'^Python[ ]+(\d+)\.(\d+)\.(\d+).*', result.output)
+    if not m:
+        raise ValueError('Cannot identify the python version: %s' % result)
+
+    return (int(m.group(1)),
+            int(m.group(2)),
+            int(m.group(3)))

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'pathspec<0.11;python_version >= "3.7"',
         'otherstuf<=1.1.0',
         'path.py>=10.5,<13',
-        'pip>=1.5.4,<23',
+        'pip>=1.5.4',
         'jujubundlelib<0.6',
         'virtualenv>=1.11.4,<21',
         'colander<1.9',

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -588,9 +588,9 @@ class TestBuild(unittest.TestCase):
             },
         })
 
-    @mock.patch('charmtools.build.tactics.getargspec')
+    @mock.patch('charmtools.build.tactics.getfullargspec')
     @mock.patch('charmtools.utils.walk')
-    def test_custom_tactics(self, mwalk, mgetargspec):
+    def test_custom_tactics(self, mwalk, mgetfullargspec):
         def _layer(tactics):
             return mock.Mock(config=build.builder.BuildConfig({'tactics':
                                                                tactics}),
@@ -617,7 +617,7 @@ class TestBuild(unittest.TestCase):
             ['third', 'second', 'first'],
         ])
 
-        mgetargspec.return_value = mock.Mock(args=[1, 2, 3, 4])
+        mgetfullargspec.return_value = mock.Mock(args=[1, 2, 3, 4])
         current_config = mock.Mock(tactics=[
             mock.Mock(name='1', **{'trigger.return_value': False}),
             mock.Mock(name='2', **{'trigger.return_value': False}),

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -179,10 +179,10 @@ class TestBuild(unittest.TestCase):
         cyaml = base / "layer.yaml"
         self.assertTrue(cyaml.exists())
         cyaml_data = yaml.safe_load(cyaml.open())
-        self.assertEquals(cyaml_data['includes'], ['layers/test-base',
+        self.assertEqual(cyaml_data['includes'], ['layers/test-base',
                                                    'layers/mysql'])
-        self.assertEquals(cyaml_data['is'], 'foo')
-        self.assertEquals(cyaml_data['options']['mysql']['qux'], 'one')
+        self.assertEqual(cyaml_data['is'], 'foo')
+        self.assertEqual(cyaml_data['options']['mysql']['qux'], 'one')
 
         self.assertTrue((base / "hooks/config-changed").exists())
 
@@ -205,13 +205,13 @@ class TestBuild(unittest.TestCase):
         sigs = base / ".build.manifest"
         self.assertTrue(sigs.exists())
         data = json.load(sigs.open())
-        self.assertEquals(data['signatures']["README.md"], [
+        self.assertEqual(data['signatures']["README.md"], [
             u'foo',
             "static",
             u'cfac20374288c097975e9f25a0d7c81783acdbc81'
             '24302ff4a731a4aea10de99'])
 
-        self.assertEquals(data["signatures"]['metadata.yaml'], [
+        self.assertEqual(data["signatures"]['metadata.yaml'], [
             u'foo',
             "dynamic",
             u'12c1f6fc865da0660f6dc044cca03b0244e883d9a99fdbdfab6ef6fc2fed63b7'
@@ -611,7 +611,7 @@ class TestBuild(unittest.TestCase):
         builder.plan_layers(layers, {})
         calls = [call[1]['current_config'].tactics
                  for call in mwalk.call_args_list]
-        self.assertEquals(calls, [
+        self.assertEqual(calls, [
             ['first'],
             ['second', 'first'],
             ['third', 'second', 'first'],
@@ -629,9 +629,9 @@ class TestBuild(unittest.TestCase):
                                  mock.Mock(),
                                  current_config,
                                  mock.Mock())
-        self.assertEquals([t.trigger.called for t in current_config.tactics],
+        self.assertEqual([t.trigger.called for t in current_config.tactics],
                           [True, True, True])
-        self.assertEquals([t.called for t in current_config.tactics],
+        self.assertEqual([t.called for t in current_config.tactics],
                           [False, False, True])
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,3 +88,12 @@ class TestUtils(TestCase):
         mock_Process().return_value = utils.ProcessResult('fakecmd', 1, '', '')
         utils.get_venv_package_list('/some/dir', env={'some': 'envvar'})
         mock_sys_exit.assert_called_once_with(1)
+
+    @unittest.mock.patch.object(utils, "Process")
+    def test_get_oython_version(self, process_klass):
+        process_klass().return_value = utils.ProcessResult(
+            ['python3', '--version'], 0, b'Python 3.12.4', b'')
+        self.assertEqual(
+            utils.get_python_version('/some/dir', env={'some': 'envvar'}),
+            (3, 12, 4)
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ deps =
     coverage
     mock
     responses
-    https://github.com/openstack-charmers/charm-templates-openstack/archive/master.zip#egg=charm_templates_openstack
     ipdb
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py3
-skipsdist = true
+package = editable
 
 [testenv]
 install_command =  pip install {opts} {packages}
@@ -18,7 +18,6 @@ deps =
     coverage
     mock
     responses
-    -e {toxinidir}
     https://github.com/openstack-charmers/charm-templates-openstack/archive/master.zip#egg=charm_templates_openstack
     ipdb
 


### PR DESCRIPTION
This PR adds support for Python 3.12, summary of changes:

* Add Python 3.12 to the testing matrix in the github workflow
* Replace `inspect.getargspec()` with `inspect.getfullargspec()`
* Replace `self.assertEquals()` with `self.assertEqual()`
* Add charmcraft 3.x/beta to the testing matrix
* Drop charm-templates-openstack from deps
* setup.py: Drop upper limit in pinning of pip

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
