### PR TITLE
Pin the version of path since 17.0 removed deprecated methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'ruamel.yaml<0.18;python_version >= "3.7"',
         'pathspec<0.11;python_version >= "3.7"',
         'otherstuf<=1.1.0',
-        'path.py>=10.5,<13',
+        'path<17',
         'pip>=1.5.4',
         'jujubundlelib<0.6',
         'virtualenv>=1.11.4,<21',


### PR DESCRIPTION
With `path==17.0.0`, some methods have been deprecated which were in use by this project

Since `path.py` was just a direct install of `path` with no restrictions, lets just remove `path.py` and pin `path`

https://github.com/jaraco/path/commit/7e23a1d7a5fc6412926e6e72be00e5479e86fec4

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [x] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
