### PR TITLE
snap: Add rust to build-packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       run: git tag v0.0.0
     - uses: snapcore/action-build@v1
       id: snap-build
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: charm-snap
         path: ${{ steps.snap-build.outputs.snap }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         repository: juju-solutions/layer-basic
 
     - name: Download built charm snap
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: charm-snap
         path: tests/charm-minimal/charm-snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,9 @@ parts:
       - libffi-dev
       - libpython3.10-dev
       - python3-pip
+      - rustc
+      - cargo
+      - pkg-config
     # Note that we cannot use any -dev type packages here, as that would pull
     # in the libc6 package.  The libc6 package contains absolute symlinks
     # pointing at /, which is not allowed in a core22 classic snap.


### PR DESCRIPTION
When building the snap on s390x some Python modules need to compile their extensions (rust based), this is not needed on amd64 since pypi has compiled packages available.

This change add rustc, cargo and pkg-config to the list of build-packages in the snapcraft.yaml definition.

Description of change

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
