### PR TITLE
snap: Add rust to build-packages [2.8 backport]

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -5,8 +5,7 @@ name: Build Snap
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  pull_request:
-    branches: [ master ]
+  pull_request
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -20,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: snapcore/action-build@v1
       id: snapcraft
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: charm.snap
         path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -19,6 +19,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: snapcore/action-build@v1
       id: snapcraft
+      with:
+        snapcraft-channel: "7.x"
     - uses: actions/upload-artifact@v4
       with:
         name: charm.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,13 @@ parts:
     source: .
     plugin: python
     python-version: python3
+    build-packages:
+      - libffi-dev
+      - libpython3.10-dev
+      - python3-pip
+      - rustc
+      - cargo
+      - pkg-config
     stage-packages:
       - git-core
       - libssl-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,7 +39,7 @@ parts:
     python-version: python3
     build-packages:
       - libffi-dev
-      - libpython3.10-dev
+      - libpython3.6-dev
       - python3-pip
       - rustc
       - cargo


### PR DESCRIPTION
When building the snap on s390x some Python modules need to compile
their extensions (rust based), this is not needed on amd64 since pypi
has compiled packages available.

This change add rustc, cargo and pkg-config to the list of
build-packages in the snapcraft.yaml definition.

* Migrate gh action actions/upload-artifact@v4

* Migration gh action actions/download-artifact@v4

The backport was adjusted to use build-snap.yml workflow instead of
test.yml

(cherry picked from commit b8747e01d3bcbc50504c6cf5e553843e13ae9f94)

## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?