### PR TITLE
add support for python 3.13

### DIFF
--- a/charmtools/diff_match_patch.py
+++ b/charmtools/diff_match_patch.py
@@ -1815,7 +1815,7 @@ class diff_match_patch:
       return patches
     text = textline.split('\n')
     while len(text) != 0:
-      m = re.match("^@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@$", text[0])
+      m = re.match(r"^@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@$", text[0])
       if not m:
         raise ValueError("Invalid patch string: " + text[0])
       patch = patch_obj()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,63 @@
+[project]
+name = "charm-tools"
+description = "Tools for building and maintaining Juju charms"
+readme = "README.rst"
+maintainers = [{ name = "Cory Johns", email = "johnsca@gmail.com" }]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python",
+]
+dependencies = [
+    "blessings<2.0",
+    "colander<1.9",
+    "ct3>=3.0.0,<4.0",
+    "dict2colander==0.2",
+    "jsonschema<4.18.0",
+    "jujubundlelib<0.6",
+    "keyring<24",
+    "otherstuf<=1.1.0",
+    "path<17",
+    "pathspec<0.11;python_version >= '3.7'",
+    "pathspec<=0.3.4;python_version < '3.7'",
+    "pip>=1.5.4",
+    "pyyaml>=5.0,!=5.4.0,!=5.4.1,!=6.0,<7.0",
+    "requests>=2.0.0,<3.0.0",
+    "requirements-parser<0.6",
+    "ruamel.yaml<0.16.0;python_version < '3.7'",
+    "ruamel.yaml<0.18;python_version >= '3.7'",
+    "secretstorage<3.4",
+    "vergit>=1.0.0,<2.0.0",
+    "virtualenv>=1.11.4,<21",
+]
+license = { text = "GPL v3" }
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/juju/charm-tools"
+
+[project.scripts]
+charm-build = "charmtools.build.builder:main"
+charm-create = "charmtools.create:main"
+charm-help = "charmtools.cli:usage"
+charm-layers = "charmtools.build.builder:inspect"
+charm-proof = "charmtools.proof:main"
+charm-pull-source = "charmtools.pullsource:main"
+charm-version = "charmtools.version:main"
+
+[project.entry-points."charmtools.templates"]
+ansible = "charmtools.templates.ansible:AnsibleCharmTemplate"
+bash = "charmtools.templates.bash:BashCharmTemplate"
+chef = "charmtools.templates.chef:ChefCharmTemplate"
+powershell = "charmtools.templates.powershell:PowerShellCharmTemplate"
+python = "charmtools.templates.python_services:PythonServicesCharmTemplate"
+python-basic = "charmtools.templates.python:PythonCharmTemplate"
+reactive-bash = "charmtools.templates.reactive_bash:ReactiveBashCharmTemplate"
+reactive-python = "charmtools.templates.reactive_python:ReactivePythonCharmTemplate"
+
+[tool.setuptools.packages.find]
+exclude = ["*tests*"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import sys
 import json
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 curdir = os.path.dirname(__file__)
@@ -37,63 +37,5 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as fh:
 
 
 setup(
-    name='charm-tools',
     version=version,
-    packages=find_packages(
-        exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-    install_requires=[
-        'ct3>=3.0.0,<4.0',
-        'pyyaml>=5.0,!=5.4.0,!=5.4.1,!=6.0,<7.0',
-        'requests>=2.0.0,<3.0.0',
-        'blessings<2.0',
-        'ruamel.yaml<0.16.0;python_version < "3.7"',
-        'pathspec<=0.3.4;python_version < "3.7"',
-        'ruamel.yaml<0.18;python_version >= "3.7"',
-        'pathspec<0.11;python_version >= "3.7"',
-        'otherstuf<=1.1.0',
-        'path<17',
-        'pip>=1.5.4',
-        'jujubundlelib<0.6',
-        'virtualenv>=1.11.4,<21',
-        'colander<1.9',
-        'jsonschema<4.18.0',
-        'keyring<24',
-        'secretstorage<3.4',
-        'dict2colander==0.2',
-        'vergit>=1.0.0,<2.0.0',
-        'requirements-parser<0.6',
-    ],
-    include_package_data=True,
-    maintainer='Cory Johns',
-    maintainer_email='johnsca@gmail.com',
-    description=('Tools for building and maintaining Juju charms'),
-    long_description=readme,
-    license='GPL v3',
-    url='https://github.com/juju/charm-tools',
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python",
-    ],
-    entry_points={
-        'console_scripts': [
-            'charm-build = charmtools.build.builder:main',
-            'charm-create = charmtools.create:main',
-            'charm-help = charmtools.cli:usage',
-            'charm-layers = charmtools.build.builder:inspect',
-            'charm-proof = charmtools.proof:main',
-            'charm-pull-source = charmtools.pullsource:main',
-            'charm-version = charmtools.version:main',
-        ],
-        'charmtools.templates': [
-            'bash = charmtools.templates.bash:BashCharmTemplate',
-            'reactive-python = charmtools.templates.reactive_python:ReactivePythonCharmTemplate',  # noqa: E501
-            'reactive-bash = charmtools.templates.reactive_bash:ReactiveBashCharmTemplate',  # noqa: E501
-            'python-basic = charmtools.templates.python:PythonCharmTemplate',
-            'python = charmtools.templates.python_services:PythonServicesCharmTemplate',  # noqa: E501
-            'ansible = charmtools.templates.ansible:AnsibleCharmTemplate',
-            'chef = charmtools.templates.chef:ChefCharmTemplate',
-            'powershell = charmtools.templates.powershell:PowerShellCharmTemplate',  # noqa: E501
-        ]
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
-        'cheetah3>=3.0.0,<4.0',
+        'ct3>=3.0.0,<4.0',
         'pyyaml>=5.0,!=5.4.0,!=5.4.1,!=6.0,<7.0',
         'requests>=2.0.0,<3.0.0',
         'blessings<2.0',

--- a/tests/layers/mysql/hooks/common.py
+++ b/tests/layers/mysql/hooks/common.py
@@ -96,7 +96,7 @@ def migrate_to_mount(new_path):
         raise RuntimeError('Persistent storage contains old data. '
                            'Please investigate and migrate data manually '
                            'to: {}'.format(new_path))
-    os.chmod(new_path, 0700)
+    os.chmod(new_path, 0o0700)
     if os.path.isdir('/etc/apparmor.d/local'):
         render('apparmor.j2', '/etc/apparmor.d/local/usr.sbin.mysqld',
                context={'path': os.path.join(new_path, '')})

--- a/tests/layers/mysql/hooks/nrpe_relations.py
+++ b/tests/layers/mysql/hooks/nrpe_relations.py
@@ -22,7 +22,7 @@ def nagios_password():
         password = str(uuid.uuid4())
         with open(PASSFILE, 'w') as f:
             f.write(password)
-        os.chmod(PASSFILE, 0600)
+        os.chmod(PASSFILE, 0o0600)
     else:
         with open(PASSFILE, 'r') as rpw:
             password = rpw.read()

--- a/tests/layers/mysql/scripts/charm_helpers_sync.py
+++ b/tests/layers/mysql/scripts/charm_helpers_sync.py
@@ -217,7 +217,7 @@ if __name__ == '__main__':
         checkout = clone_helpers(tmpd, config['branch'])
         sync_helpers(config['include'], checkout, config['destination'],
                      options=sync_options)
-    except Exception, e:
+    except Exception as e:
         logging.error("Could not sync: %s" % e)
         raise e
     finally:


### PR DESCRIPTION
This PR contains a couple of fixes for python 3.13:

* `cheetah3` has been [renamed to `ct3`](https://github.com/CheetahTemplate3/cheetah3/commit/673259b2d139b4ea970b1c2da12607b7ac39cbec), with the former no longer being updated and broken on 3.13: https://github.com/CheetahTemplate3/cheetah3/issues/63
* Invalid escape sequences now raise a `SyntaxWarning` on 3.12+: https://docs.python.org/3/whatsnew/3.12.html#other-language-changes
* While here, migrate mostly to [`pyproject.toml`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/) (the modern replacement for `setup.py` favoring static metadata). Now only the dynamic `version` remains in `setup.py`.

## Checklist

- [x] Are all your commits [logically] grouped and squashed appropriately?
- [ ] Does this patch have code coverage?
- [ ] Does your code pass `make test`?
