### PR TITLE
Add --ignore-requires-python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
               - -v
               - --binary-wheels-from-source
               - --upgrade-buildvenv-core-deps
+              - --ignore-requires-python
             build-packages:
               - python3-dev
               - libpq-dev
@@ -131,6 +132,7 @@ jobs:
               - -v
               - --binary-wheels-from-source
               - --upgrade-buildvenv-core-deps
+              - --ignore-requires-python
             build-packages:
               - python3-dev
               - libpq-dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,6 @@ jobs:
             reactive-charm-build-arguments:
               - -v
               - --binary-wheels-from-source
-              - --upgrade-buildvenv-core-deps
               - --ignore-requires-python
             build-packages:
               - python3-dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,8 @@ jobs:
     - name: Upload built charms
       uses: actions/upload-artifact@v4
       with:
-        name: Built charms ${{ matrix.runs-on }}
+        name: Built charms
+        overwrite: true
         path: |
           minimal_ubuntu-18.04-amd64.charm
           minimal_ubuntu-20.04-amd64.charm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,14 +146,14 @@ jobs:
     #   uses: lhotari/action-upterm@v1
     - name: Upload charmcraft execution logs
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: charmcraft execution logs
+        name: charmcraft execution logs ${{ matrix.runs-on }}
         path: ~/snap/charmcraft/common/cache/charmcraft/log/*.log
     - name: Upload built charms
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: Built charms
+        name: Built charms ${{ matrix.runs-on }}
         path: |
           minimal_ubuntu-18.04-amd64.charm
           minimal_ubuntu-20.04-amd64.charm

--- a/charmtools/build/builder.py
+++ b/charmtools/build/builder.py
@@ -1208,6 +1208,12 @@ def main(args=None):
                         help='Upgrade core dependencies in virtualenv used to '
                         'build/download wheels: pip setuptools to the latest '
                         'version in PyPI.')
+    parser.add_argument('--ignore-requires-python', action='store_true',
+                        default=False,
+                        help='This flag instructs pip to bypass the '
+                        'Requires-Python metadata specified by the package, '
+                        'which typically indicates the Python versions it '
+                        'officially supports.')
     parser.add_argument('charm', nargs="?", default=".", type=path,
                         help='Source directory for charm layer to build '
                              '(default: .)')
@@ -1230,6 +1236,7 @@ def main(args=None):
     WheelhouseTactic.binary_build_from_source = build.binary_wheels_from_source
     WheelhouseTactic.use_python_from_snap = build.use_python_from_snap
     WheelhouseTactic.upgrade_deps = build.upgrade_buildvenv_core_deps
+    WheelhouseTactic.ignore_requires_python = build.ignore_requires_python
 
     configLogging(build)
 

--- a/charmtools/build/tactics.py
+++ b/charmtools/build/tactics.py
@@ -1048,6 +1048,7 @@ class WheelhouseTactic(ExactMatch, Tactic):
     binary_build_from_source = False
     use_python_from_snap = False
     upgrade_deps = False
+    ignore_requires_python = False
 
     def __init__(self, *args, **kwargs):
         super(WheelhouseTactic, self).__init__(*args, **kwargs)
@@ -1125,15 +1126,21 @@ class WheelhouseTactic(ExactMatch, Tactic):
         with utils.tempdir(chdir=False) as temp_dir:
             # put in a temp dir first to ensure we track all of the files
             _no_binary_opts = ('--no-binary', ':all:')
+            _ignore_requires_python = ('--ignore-requires-python', )
             try:
                 if self.binary_build_from_source or self.binary_build:
                     self._pip('wheel',
                               *_no_binary_opts
                               if self.binary_build_from_source else tuple(),
+                              *_ignore_requires_python
+                              if self.ignore_requires_python else tuple(),
                               '-w', temp_dir, *reqs)
                 else:
-                    self._pip(
-                        'download', *_no_binary_opts, '-d', temp_dir, *reqs)
+                    self._pip('download',
+                              *_no_binary_opts,
+                              *_ignore_requires_python
+                              if self.ignore_requires_python else tuple(),
+                              '-d', temp_dir, *reqs)
             except BuildError:
                 log.info('Build failed. If you are building on Focal and have '
                          'Jinja2 or MarkupSafe as part of your dependencies, '

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'dict2colander==0.2',
         'vergit>=1.0.0,<2.0.0',
         'requirements-parser<0.6',
-        'importlib-resources',
     ],
     include_package_data=True,
     maintainer='Cory Johns',

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'dict2colander==0.2',
         'vergit>=1.0.0,<2.0.0',
         'requirements-parser<0.6',
+        'importlib-resources',
     ],
     include_package_data=True,
     maintainer='Cory Johns',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,7 @@ parts:
       - python3-pip
       - python3-setuptools
       - python3-distutils
+      - python3-importlib-resources
       - python3-pkg-resources
       - python3-virtualenv
       - python3-requests


### PR DESCRIPTION
This new flag allows to instruct pip to ignore if the Python version is
explicitly supported by the package.
    
This flag is helpful to build old charms that are using a src/build.lock
where the package doesn't explicitly states support, this was detected
in charm-octavia[0]

[0] https://review.opendev.org/c/openstack/charm-octavia/+/962501/1#message-7dd7c13d1ef1ff20312e63f105c362aa8e9bf5c1


## Checklist

 - [x] Are all your commits [logically] grouped and squashed appropriately?
 - [ ] Does this patch have code coverage?
 - [x] Does your code pass `make test`?
